### PR TITLE
Stop ignoring the composer.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 .DS_Store
 Thumbs.db
 composer.phar
-composer.lock


### PR DESCRIPTION
Seriously, this should not be ignored.
You need to make sure other people are getting the right versions of your packages.