### PR TITLE
Removed Key Generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
       "php artisan optimize"
     ],
     "post-create-project-cmd": [
-      "php artisan key:generate",
       "php artisan cache:clear"
     ]
   },


### PR DESCRIPTION
This line is not needed, because it has no effect.

php artisan asgard:install will generate the correct key