### PR TITLE
Fix the UserWasUpdated event only receiving boolean on update

### DIFF
--- a/Modules/User/Events/UserIsUpdating.php
+++ b/Modules/User/Events/UserIsUpdating.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\User\Events;
+
+class UserIsUpdating
+{
+    public $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/Modules/User/Events/UserWasCreated.php
+++ b/Modules/User/Events/UserWasCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\User\Events;
+
+class UserWasCreated
+{
+    public $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
+++ b/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
@@ -115,7 +115,7 @@ class SentinelUserRepository implements UserRepository
      */
     public function update($user, $data)
     {
-        $user = $user->update($data);
+        $user->update($data);
 
         event(new UserWasUpdated($user));
 

--- a/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
+++ b/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
@@ -68,14 +68,10 @@ class SentinelUserRepository implements UserRepository
     public function createWithRoles($data, $roles, $activated = false)
     {
         $this->hashPassword($data);
-        $user = $this->create((array) $data);
+        $user = $this->create((array) $data, $activated);
 
         if (!empty($roles)) {
             $user->roles()->attach($roles);
-        }
-
-        if ($activated) {
-            $this->activateUser($user);
         }
     }
 
@@ -90,14 +86,10 @@ class SentinelUserRepository implements UserRepository
     public function createWithRolesFromCli($data, $roles, $activated = false)
     {
         $this->hashPassword($data);
-        $user = $this->user->create((array) $data);
+        $user = $this->user->create((array) $data, $activated);
 
         if (!empty($roles)) {
             $user->roles()->attach($roles);
-        }
-
-        if ($activated) {
-            $this->activateUser($user);
         }
 
         return $user;

--- a/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
+++ b/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
@@ -7,6 +7,7 @@ use Cartalyst\Sentinel\Laravel\Facades\Sentinel;
 use Illuminate\Support\Facades\Hash;
 use Modules\User\Entities\Sentinel\User;
 use Modules\User\Events\UserHasRegistered;
+use Modules\User\Events\UserIsUpdating;
 use Modules\User\Events\UserWasCreated;
 use Modules\User\Events\UserWasUpdated;
 use Modules\User\Exceptions\UserNotFoundException;
@@ -120,7 +121,11 @@ class SentinelUserRepository implements UserRepository
      */
     public function update($user, $data)
     {
-        $user->update($data);
+        $user->fill($data);
+
+        event(new UserIsUpdating($user));
+
+        $user->save();
 
         event(new UserWasUpdated($user));
 
@@ -143,6 +148,9 @@ class SentinelUserRepository implements UserRepository
         $this->checkForManualActivation($user, $data);
 
         $user = $user->fill($data);
+
+        event(new UserIsUpdating($user));
+
         $user->save();
 
         event(new UserWasUpdated($user));


### PR DESCRIPTION
The `save` method (which `update` calls), only returns boolean.

Also changed around the `create` and `createWithRoles` methods so activation email isn't sent if the boolean `$activated` is `true`.

This PR also includes a new event that fires before saving when updating.