### PR TITLE
When scaffolding new modules, use the new namespace for the Core module

### DIFF
--- a/Modules/Workshop/Scaffold/Module/ModuleScaffold.php
+++ b/Modules/Workshop/Scaffold/Module/ModuleScaffold.php
@@ -305,7 +305,7 @@ JSON;
     "require": {
         "php": ">=5.6",
         "composer/installers": "~1.0",
-        "asgardcms/core-module": "~2.0"
+        "idavoll/core-module": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
https://github.com/AsgardCms/Core/tree/2.0 and https://github.com/Idavoll/Core/tree/2.0 are out of sync now.