### PR TITLE
Fix slug script to allow changing the slugContainer via data attributes

### DIFF
--- a/Themes/AdminLTE/assets/js/vendor/jquery.slug.js
+++ b/Themes/AdminLTE/assets/js/vendor/jquery.slug.js
@@ -6,21 +6,21 @@
 
 jQuery.fn.slug = function (options) {
     var settings = {
-        slug: 'slug', // Class used for slug destination input and span. The span is created on $(document).ready()
+        slug: '[data-slug="target"]', // Element used for slug's target
         override: false
     };
 
-    $this = jQuery(this);
-
-    var slugContainer = $this.closest('.box-body').find('[data-slug="target"]');
-
     if (options) {
         jQuery.extend(settings, options);
-    } else {
-        if (typeof $this.data('target') !== "undefined") {
-            settings.slug = $this.data('target');
-        }
     }
+
+    $this = jQuery(this);
+
+    if (typeof $this.data('target') !== "undefined") {
+        settings.slug = $this.data('target');
+    }
+
+    var slugContainer = $this.closest('.box-body').find(settings.slug);
 
     makeSlug = function (event) {
         var $theUnSlug = jQuery(event.target),

--- a/public/themes/adminlte/js/vendor/jquery.slug.js
+++ b/public/themes/adminlte/js/vendor/jquery.slug.js
@@ -6,21 +6,21 @@
 
 jQuery.fn.slug = function (options) {
     var settings = {
-        slug: 'slug', // Class used for slug destination input and span. The span is created on $(document).ready()
+        slug: '[data-slug="target"]', // Element used for slug's target
         override: false
     };
 
-    $this = jQuery(this);
-
-    var slugContainer = $this.closest('.box-body').find('[data-slug="target"]');
-
     if (options) {
         jQuery.extend(settings, options);
-    } else {
-        if (typeof $this.data('target') !== "undefined") {
-            settings.slug = $this.data('target');
-        }
     }
+
+    $this = jQuery(this);
+
+    if (typeof $this.data('target') !== "undefined") {
+        settings.slug = $this.data('target');
+    }
+
+    var slugContainer = $this.closest('.box-body').find(settings.slug);
 
     makeSlug = function (event) {
         var $theUnSlug = jQuery(event.target),


### PR DESCRIPTION
Fixes slugs being generated in the first slugContainer with
`[data-slug="target"]` on the page.

Usage:

Add a `data-target` to your source and set the value to be the element
you want to use for the slug target. Valid values are anything that
jQuery can parse in the `.find()` method.
