### PR TITLE
Add sidebar permissions to allow turning groups on/off globally

### DIFF
--- a/Modules/Core/Config/permissions.php
+++ b/Modules/Core/Config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'core.sidebar' => [
+        'group' => 'core::sidebar.show group',
+    ],
+];

--- a/Modules/Core/Sidebar/SidebarExtender.php
+++ b/Modules/Core/Sidebar/SidebarExtender.php
@@ -6,7 +6,6 @@ use Maatwebsite\Sidebar\Badge;
 use Maatwebsite\Sidebar\Group;
 use Maatwebsite\Sidebar\Item;
 use Maatwebsite\Sidebar\Menu;
-use Modules\Page\Repositories\PageRepository;
 use Modules\User\Contracts\Authentication;
 
 class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
@@ -34,18 +33,10 @@ class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
     public function extendWith(Menu $menu)
     {
         $menu->group(trans('core::sidebar.content'), function (Group $group) {
-            $group->item(trans('page::pages.title.pages'), function (Item $item) {
-                $item->icon('fa fa-file');
-                $item->weight(1);
-                $item->route('admin.page.page.index');
-                $item->badge(function (Badge $badge, PageRepository $page) {
-                    $badge->setClass('bg-green');
-                    $badge->setValue($page->countAll());
-                });
-                $item->authorize(
-                    $this->auth->hasAccess('page.pages.index')
-                );
-            });
+            $group->weight(50);
+            $group->authorize(
+                $this->auth->hasAccess('core.sidebar.group')
+            );
         });
 
         return $menu;

--- a/Modules/Core/Sidebar/SidebarExtender.php
+++ b/Modules/Core/Sidebar/SidebarExtender.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Page\Sidebar;
+namespace Modules\Core\Sidebar;
 
 use Maatwebsite\Sidebar\Badge;
 use Maatwebsite\Sidebar\Group;

--- a/Modules/Translation/Resources/lang/core/en/sidebar.php
+++ b/Modules/Translation/Resources/lang/core/en/sidebar.php
@@ -2,4 +2,5 @@
 
 return [
     'content' => 'Content',
+    'show group' => 'Show sidebar group',
 ];

--- a/Modules/Translation/Resources/lang/workshop/en/themes.php
+++ b/Modules/Translation/Resources/lang/workshop/en/themes.php
@@ -10,4 +10,5 @@ return [
     'type' => 'Type',
     'list resource' => 'List themes',
     'show resource' => 'View themes',
+    'publish assets' => 'Publish assets',
 ];

--- a/Modules/Translation/Resources/lang/workshop/en/workshop.php
+++ b/Modules/Translation/Resources/lang/workshop/en/workshop.php
@@ -4,4 +4,5 @@ return [
     'title'   => 'Workshop',
     'modules' => 'Modules',
     'themes' => 'Themes',
+    'show sidebar group' => 'See sidebar group',
 ];

--- a/Modules/User/Database/Seeders/SentinelGroupSeedTableSeeder.php
+++ b/Modules/User/Database/Seeders/SentinelGroupSeedTableSeeder.php
@@ -38,17 +38,22 @@ class SentinelGroupSeedTableSeeder extends Seeder
         // Save the permissions
         $group = Sentinel::findRoleBySlug('admin');
         $group->permissions = [
+            'core.sidebar.group' => true,
+            /* Dashboard */
             'dashboard.index' => true,
             'dashboard.update' => true,
             'dashboard.reset' => true,
             /* Workbench */
+            'workshop.sidebar.group' => true,
             'workshop.modules.index' => true,
             'workshop.modules.show' => true,
+            'workshop.modules.update' => true,
             'workshop.modules.disable' => true,
             'workshop.modules.enable' => true,
-            'workshop.modules.update' => true,
+            'workshop.modules.publish' => true,
             'workshop.themes.index' => true,
             'workshop.themes.show' => true,
+            'workshop.themes.publish' => true,
             /* Roles */
             'user.roles.index' => true,
             'user.roles.create' => true,

--- a/Modules/Workshop/Config/permissions.php
+++ b/Modules/Workshop/Config/permissions.php
@@ -1,17 +1,20 @@
 <?php
 
 return [
+    'workshop.sidebar' => [
+        'group' => 'workshop::workshop.show sidebar group',
+    ],
     'workshop.modules' => [
         'index' => 'workshop::modules.list resource',
         'show' => 'workshop::modules.show resource',
         'update' => 'workshop::modules.update resource',
         'disable' => 'workshop::modules.disable resource',
         'enable' => 'workshop::modules.enable resource',
-        'publish' => 'workshop::modules.publish assets'
+        'publish' => 'workshop::modules.publish assets',
     ],
     'workshop.themes' => [
         'index' => 'workshop::themes.list resource',
         'show' => 'workshop::themes.show resource',
-        'publish' => 'workshop::themes.publish assets'
+        'publish' => 'workshop::themes.publish assets',
     ],
 ];

--- a/Modules/Workshop/Sidebar/SidebarExtender.php
+++ b/Modules/Workshop/Sidebar/SidebarExtender.php
@@ -33,6 +33,9 @@ class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
     {
         $menu->group(trans('workshop::workshop.title'), function (Group $group) {
             $group->weight(100);
+            $group->authorize(
+                $this->auth->hasAccess('workshop.sidebar.group')
+            );
             $group->item(trans('workshop::workshop.modules'), function (Item $item) {
                 $item->icon('fa fa-cogs');
                 $item->weight(100);
@@ -49,10 +52,6 @@ class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
                     $this->auth->hasAccess('workshop.themes.index')
                 );
             });
-
-            $group->authorize(
-                $this->auth->hasAccess('workshop.*') or $this->auth->hasAccess('user.*') or $this->auth->hasAccess('setting.*')
-            );
         });
 
         return $menu;


### PR DESCRIPTION
Closes #276

- Add missing language line for workshop themes

- Add missing permissions from AsgardCms/Workshop#31 to permissions seed

- Add Workshop permission to globally turn on/off sidebar group

- Remove permissions check on core sidebar group

- Sort permission seeder in order of permissions config file