### PR TITLE
Input issue when number is zero

### DIFF
--- a/Modules/Core/macros.php
+++ b/Modules/Core/macros.php
@@ -198,7 +198,7 @@ Form::macro('normalInput', function ($name, $title, ViewErrorBag $errors, $objec
     $string .= Form::label($name, $title);
 
     if (is_object($object)) {
-        $currentData = $object->{$name} ?: '';
+        $currentData = isset($object->{$name}) ? isset($object->{$name}) : '';
     } else {
         $currentData = null;
     }
@@ -228,7 +228,7 @@ Form::macro('normalInputOfType', function ($type, $name, $title, ViewErrorBag $e
     $string .= Form::label($name, $title);
 
     if (is_object($object)) {
-        $currentData = $object->{$name} ?: '';
+        $currentData = isset($object->{$name}) ? isset($object->{$name}) : '';
     } else {
         $currentData = null;
     }


### PR DESCRIPTION
Input with number zero return empty value:

For instance: $object->test = 0

```php
{!! Form:: normalInput('test', 'Test', $errors, $object) !!} 
```

Result:

```php
<input class="form-control" placeholder="Test" name="test" type="text" value="">
```
Instead of

```php
<input class="form-control" placeholder="Test" name="test" type="text" value="0">
```

Same for 

```php
{!! Form:: normalTextarea('test', 'Test', $errors, $object) !!} 
```





Return empty value instead of 0
