### PR TITLE
Check for password change when updating user

### DIFF
--- a/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
+++ b/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
@@ -120,6 +120,8 @@ class SentinelUserRepository implements UserRepository
      */
     public function update($user, $data)
     {
+        $this->checkForNewPassword($data);
+
         $user->fill($data);
 
         event(new UserIsUpdating($user));


### PR DESCRIPTION
When updating a user via "My Account -> Profile", if the password field was blank it would remove the user's password completely. If the user changed their password, it would be saved to the database **without** being hashed first.