### PR TITLE
Check if ‘password’ key exists before unsetting

### DIFF
--- a/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
+++ b/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
@@ -202,7 +202,7 @@ class SentinelUserRepository implements UserRepository
      */
     private function checkForNewPassword(array &$data)
     {
-        if (! $data['password']) {
+        if (array_key_exists('password', $data) && ($data['password'] === '' || $data['password'] === null)) {
             unset($data['password']);
 
             return;


### PR DESCRIPTION
This fixes errors introduced in #294, if the request data does not contain a password field.