### PR TITLE
Feature/extra view namespaces

### DIFF
--- a/Modules/Core/Config/config.php
+++ b/Modules/Core/Config/config.php
@@ -14,4 +14,24 @@ return [
         'setting',
         'media',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | Available places are: from within your current backend theme, from within
+    | your current frontend theme and from resources folder.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/Core/Config/config.php
+++ b/Modules/Core/Config/config.php
@@ -22,8 +22,6 @@ return [
     | You can specify place from which you would like to use module views.
     | You can use any combination, but generally it's advisable to add only one,
     | extra view namespace.
-    | Available places are: from within your current backend theme, from within
-    | your current frontend theme and from resources folder.
     | By default every extra namespace will be set to false.
     */
     'useViewNamespaces' => [

--- a/Modules/Core/Config/core.php
+++ b/Modules/Core/Config/core.php
@@ -112,40 +112,47 @@ return [
         'clipboard.js' => ['theme' => 'vendor/clipboard/dist/clipboard.min.js'],
     ],
 
-   /*
-   |--------------------------------------------------------------------------
-   | Define which default assets will always be included in your pages
-   | through the asset pipeline
-   |--------------------------------------------------------------------------
-   */
-   'admin-required-assets' => [
-       'css' => [
-           'bootstrap.css',
-           'font-awesome.css',
-           'alertify.core.css',
-           'alertify.default.css',
-           'dataTables.bootstrap.css',
-           'icheck.blue.css',
-           'AdminLTE.css',
-           'AdminLTE.all.skins.css',
-           'animate.css',
-           'pace.css',
-           'selectize-default.css',
-           'asgard.css',
-       ],
-       'js' => [
-           'bootstrap.js',
-           'mousetrap.js',
-           'alertify.js',
-           'icheck.js',
-           'jquery.dataTables.js',
-           'dataTables.bootstrap.js',
-           'jquery.slug.js',
-           'keypressAction.js',
-           'app.js',
-           'pace.js',
-           'selectize.js',
-           'main.js',
-       ],
-   ],
+    /*
+    |--------------------------------------------------------------------------
+    | Define which default assets will always be included in your pages
+    | through the asset pipeline
+    |--------------------------------------------------------------------------
+    */
+    'admin-required-assets' => [
+        'css' => [
+            'bootstrap.css',
+            'font-awesome.css',
+            'alertify.core.css',
+            'alertify.default.css',
+            'dataTables.bootstrap.css',
+            'icheck.blue.css',
+            'AdminLTE.css',
+            'AdminLTE.all.skins.css',
+            'animate.css',
+            'pace.css',
+            'selectize-default.css',
+            'asgard.css',
+        ],
+        'js' => [
+            'bootstrap.js',
+            'mousetrap.js',
+            'alertify.js',
+            'icheck.js',
+            'jquery.dataTables.js',
+            'dataTables.bootstrap.js',
+            'jquery.slug.js',
+            'keypressAction.js',
+            'app.js',
+            'pace.js',
+            'selectize.js',
+            'main.js',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable module view overrides at theme locations
+    |--------------------------------------------------------------------------
+    */
+    'enable-theme-overrides' => false,
 ];

--- a/Modules/Core/helpers.php
+++ b/Modules/Core/helpers.php
@@ -26,3 +26,10 @@ if (! function_exists('is_module_enabled')) {
         return array_key_exists($module, app('modules')->enabled());
     }
 }
+
+if (! function_exists('is_core_module')) {
+    function is_core_module($module)
+    {
+        return in_array(strtolower($module), app('asgard.ModulesList'));
+    }
+}

--- a/Modules/Dashboard/Config/config.php
+++ b/Modules/Dashboard/Config/config.php
@@ -10,4 +10,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => true,
+    ],
 ];

--- a/Modules/Dashboard/Providers/DashboardServiceProvider.php
+++ b/Modules/Dashboard/Providers/DashboardServiceProvider.php
@@ -46,10 +46,6 @@ class DashboardServiceProvider extends ServiceProvider
 
         $this->app['view']->prependNamespace(
             'dashboard',
-            base_path('resources/views/asgard/dashboard')
-        );
-        $this->app['view']->prependNamespace(
-            'dashboard',
             $theme->find(config('asgard.core.core.admin-theme'))->getPath() . '/views/modules/dashboard'
         );
 

--- a/Modules/Media/Config/config.php
+++ b/Modules/Media/Config/config.php
@@ -48,4 +48,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/Menu/Config/config.php
+++ b/Modules/Menu/Config/config.php
@@ -18,4 +18,22 @@ return [
     | having to send it via the views
     */
     'default_menu_presenter' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/Page/Config/config.php
+++ b/Modules/Page/Config/config.php
@@ -53,4 +53,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/Setting/Config/config.php
+++ b/Modules/Setting/Config/config.php
@@ -10,4 +10,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/Tag/Config/config.php
+++ b/Modules/Tag/Config/config.php
@@ -12,4 +12,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/Translation/Config/config.php
+++ b/Modules/Translation/Config/config.php
@@ -18,4 +18,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];

--- a/Modules/User/Config/config.php
+++ b/Modules/User/Config/config.php
@@ -98,4 +98,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => true,
+    ],
 ];

--- a/Modules/User/Providers/UserServiceProvider.php
+++ b/Modules/User/Providers/UserServiceProvider.php
@@ -67,8 +67,6 @@ class UserServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../Resources/views' => base_path('resources/views/asgard/user'),
         ]);
-        $this->loadViewsFrom(base_path('resources/views/asgard/user'), 'user');
-        $this->loadViewsFrom(__DIR__ . '/../Resources/views', 'user');
 
         $this->publishConfig('user', 'permissions');
         $this->publishConfig('user', 'config');

--- a/Modules/Workshop/Config/config.php
+++ b/Modules/Workshop/Config/config.php
@@ -10,4 +10,22 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load additional view namespaces for a module
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use module views.
+    | You can use any combination, but generally it's advisable to add only one,
+    | extra view namespace.
+    | By default every extra namespace will be set to false.
+    */
+    'useViewNamespaces' => [
+        // Read module views from /Themes/<backend-theme-name>/views/modules/asgard/<module-name>
+        'backend-theme' => false,
+        // Read module views from /Themes/<frontend-theme-name>/views/modules/asgard/<module-name>
+        'frontend-theme' => false,
+        // Read module views from /resources/views/asgard/<module-name>
+        'resources' => false,
+    ],
 ];


### PR DESCRIPTION
With this change user can request additional viewNamespaces for any of core modules, this will not publish views, but will only add viewNamespace to the system.

For core modules, it means no need to declare namespaces in ServiceProvider, can do it in module config, but it's possible to add explicit additional viewNamespace in ServiceProvider, so it will always load no matter what setting there is in any config.