### PR TITLE
Upgrade dynamic relationships on User to allow for better usability

### DIFF
--- a/Modules/User/Config/config.php
+++ b/Modules/User/Config/config.php
@@ -79,15 +79,12 @@ return [
     'casts' => [
     ],
     /*
-     |--------------------------------------------------------------------------
-     | Dynamic relations
-     |--------------------------------------------------------------------------
-     | Add relations that will be dynamically added to the User entity
-     */
-    'relations' => [
-//        'extension' => function ($self) {
-//            return $self->belongsTo(UserExtension::class, 'user_id', 'id')->first();
-//        }
+    |--------------------------------------------------------------------------
+    | Custom with fields
+    |--------------------------------------------------------------------------
+    | Set the relationships that will be automatically loaded with the User
+    */
+    'with' => [
     ],
     /*
     |--------------------------------------------------------------------------

--- a/config/asgard/user/config.php
+++ b/config/asgard/user/config.php
@@ -79,15 +79,12 @@ return [
     'casts' => [
     ],
     /*
-     |--------------------------------------------------------------------------
-     | Dynamic relations
-     |--------------------------------------------------------------------------
-     | Add relations that will be dynamically added to the User entity
-     */
-    'relations' => [
-//        'extension' => function ($self) {
-//            return $self->belongsTo(UserExtension::class, 'user_id', 'id')->first();
-//        }
+    |--------------------------------------------------------------------------
+    | Custom with fields
+    |--------------------------------------------------------------------------
+    | Set the relationships that will be automatically loaded with the User
+    */
+    'with' => [
     ],
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Credits to @xLink for the `Macroable` idea

Squashed commits:
[78815e2] Use Macros instead of a config option to setup relationships

Side-effect of this is that accessors and mutators should also work now
[de7fd29] Allow setting `$with` property, so relationships can be automatically
loaded by Eloquent when getting an entity
[b5cd00d] Fix docblock
[d60d70d] Implement the PresentableInterface as well