### PR TITLE
Allow user Welcome and Password Reset email subjects to be translated

### DIFF
--- a/Modules/Translation/Resources/lang/user/en/messages.php
+++ b/Modules/Translation/Resources/lang/user/en/messages.php
@@ -11,6 +11,9 @@ return [
     'user no longer exists' => 'The user no longer exists.',
     'invalid reset code' => 'Invalid or expired reset code.',
     'password reset' => 'Password has been reset. You can now login with your new password.',
+    /* Email subjects */
+    'welcome' => 'Welcome.',
+    'reset password' => 'Reset your account password.',
     /* User management */
     'user created' => 'User successfully created.',
     'user not found' => 'User not found.',

--- a/Modules/User/Emails/ResetPasswordEmail.php
+++ b/Modules/User/Emails/ResetPasswordEmail.php
@@ -36,6 +36,6 @@ class ResetPasswordEmail extends Mailable implements ShouldQueue
     public function build()
     {
         return $this->view('user::emails.reminder')
-            ->subject(trans('reset password'));
+            ->subject(trans('user::messages.reset password'));
     }
 }

--- a/Modules/User/Emails/ResetPasswordEmail.php
+++ b/Modules/User/Emails/ResetPasswordEmail.php
@@ -16,11 +16,11 @@ class ResetPasswordEmail extends Mailable implements ShouldQueue
      * @var UserInterface
      */
     public $user;
+
     /**
      * @var
      */
     public $code;
-    protected $subject = 'Reset your account password.';
 
     public function __construct(UserInterface $user, $code)
     {
@@ -35,6 +35,7 @@ class ResetPasswordEmail extends Mailable implements ShouldQueue
      */
     public function build()
     {
-        return $this->view('user::emails.reminder');
+        return $this->view('user::emails.reminder')
+            ->subject(trans('reset password'));
     }
 }

--- a/Modules/User/Emails/WelcomeEmail.php
+++ b/Modules/User/Emails/WelcomeEmail.php
@@ -16,12 +16,11 @@ class WelcomeEmail extends Mailable implements ShouldQueue
      * @var UserInterface
      */
     public $user;
+
     /**
      * @var
      */
     public $activationCode;
-
-    protected $subject = 'Welcome.';
 
     public function __construct(UserInterface $user, $activationCode)
     {
@@ -36,6 +35,7 @@ class WelcomeEmail extends Mailable implements ShouldQueue
      */
     public function build()
     {
-        return $this->view('user::emails.welcome');
+        return $this->view('user::emails.welcome')
+            ->subject(trans('user::messages.welcome'));
     }
 }


### PR DESCRIPTION
Also has a side effect of adding compatibility with Laravel =< 5.3.29, if the tests would also pass…