### PR TITLE
Kay899 patch 1

### DIFF
--- a/Modules/Translation/Resources/lang/user/en/users.php
+++ b/Modules/Translation/Resources/lang/user/en/users.php
@@ -57,6 +57,7 @@ return [
     'you have no api keys' => 'You have no API keys.',
     'generate one' => 'Generate one.',
     'token generated' => 'API token was successfully generated',
+    'token deleted' => 'API token was successfully deleted',
     'list user' => 'List users',
     'create user' => 'Create users',
     'edit user' => 'Edit users',

--- a/Modules/User/Http/Controllers/Admin/Account/ApiKeysController.php
+++ b/Modules/User/Http/Controllers/Admin/Account/ApiKeysController.php
@@ -40,7 +40,7 @@ class ApiKeysController extends AdminBaseController
         $this->userToken->generateFor($this->auth->id());
 
         return redirect()->route('admin.account.api.index')
-            ->withSuccess(trans('user:users.token generated'));
+            ->withSuccess(trans('user::users.token generated'));
     }
 
     public function destroy(UserToken $userToken)
@@ -48,6 +48,6 @@ class ApiKeysController extends AdminBaseController
         $this->userToken->destroy($userToken);
 
         return redirect()->route('admin.account.api.index')
-            ->withSuccess(trans('core::core.messages.resource deleted', ['name' => 'Api Token']));
+            ->withSuccess(trans('user::users.token deleted'));
     }
 }


### PR DESCRIPTION
Fixing typo error for lang
1) Fixing a typo error for success message
2) Use individual success message for deleting an API key
With this change everyone can add his own translations