### PR TITLE
Update to Laravel 5.4 Sessions:Symfony Compatibility

### DIFF
--- a/Modules/Setting/Http/Controllers/Admin/SettingController.php
+++ b/Modules/Setting/Http/Controllers/Admin/SettingController.php
@@ -49,7 +49,7 @@ class SettingController extends AdminBaseController
 
     public function getModuleSettings(Module $currentModule)
     {
-        $this->session->set('module', $currentModule->getLowerName());
+        $this->session->put('module', $currentModule->getLowerName());
 
         $modulesWithSettings = $this->setting->moduleSettings($this->module->enabled());
 


### PR DESCRIPTION
See https://laravel.com/docs/5.4/upgrade

->set() method should be changed to ->put()

....

Sessions:Symfony Compatibility

Laravel's session handlers no longer implements Symfony's SessionInterface. Implementing this interface required us to implement extraneous features that were not needed by the framework. Instead, a new Illuminate\Contracts\Session\Session interface has been defined and may be used instead. The following code changes should also be applied:

All calls to the ->set() method should be changed to ->put(). Typically, Laravel applications would never call the set method since it has never been documented within the Laravel documentation. However, it is included here out of caution.

All calls to the ->getToken() method should be changed to ->token().

All calls to the $request->setSession() method should be changed to setLaravelSession().