### PR TITLE
use “where” clause for fetching translation by key instead of “whereKey”

### DIFF
--- a/Modules/Translation/Repositories/Eloquent/EloquentTranslationRepository.php
+++ b/Modules/Translation/Repositories/Eloquent/EloquentTranslationRepository.php
@@ -17,7 +17,7 @@ class EloquentTranslationRepository extends EloquentBaseRepository implements Tr
     {
         $locale = $locale ?: app()->getLocale();
 
-        $translation = $this->model->whereKey($key)->with('translations')->first();
+        $translation = $this->model->where('key', $key)->with('translations')->first();
         if ($translation && $translation->hasTranslation($locale)) {
             return $translation->translate($locale)->value;
         }


### PR DESCRIPTION
When i tried to use "Translator", i figured out that the "EloquentTranslationRepository::findByKeyAndLocale" is using wrong clause for fetching the result of the translation record in database.

For example,

```php
public function findByKeyAndLocale($key, $locale = null)
{
        $locale = $locale ?: app()->getLocale();

        // when using "whereKey" clause, it will always return null. 
        // coz, it's fetching the id instead of "key" field.
        $translation = $this->model->whereKey($key)->with('translations')->first();

        // its now getting the result correctly.
        $translation = $this->model->where('key', $key)->with('translations')->first();

        if ($translation && $translation->hasTranslation($locale)) {
            return $translation->translate($locale)->value;
        }

        return '';
} 
```

And also reference to "BuildTranslationsCacheCommand" line 30,

```php
$this->translation->findByKeyAndLocale($translation->key, $locale);
```

Its using "key" for finding the result. So, i'm making this PR for fixing this little bug.