### PR TITLE
Add custom stubs folder

### DIFF
--- a/Modules/Workshop/Config/config.php
+++ b/Modules/Workshop/Config/config.php
@@ -3,6 +3,18 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Custom Stubs Folder
+    |--------------------------------------------------------------------------
+    | You can specify place from which you would like to use stubs.
+    | e.g. "Modules/<module-name>/Resources/views/stubs"
+    | Only the customized stubs need to be in this folder. 
+    | All other stubs will be loaded from Workshop Module folder.
+    | No custom stubs folder: null
+    */
+    'custom-stubs-folder' => null,
+    
+    /*
+    |--------------------------------------------------------------------------
     | Custom Sidebar Class
     |--------------------------------------------------------------------------
     | If you want to customise the admin sidebar ordering or grouping

--- a/Modules/Workshop/Scaffold/Module/Generators/Generator.php
+++ b/Modules/Workshop/Scaffold/Module/Generators/Generator.php
@@ -85,12 +85,9 @@ abstract class Generator
     {
         $folder = $this->config->get('asgard.workshop.config.custom-stubs-folder');
 
-        if ($folder !== null)
-        {
+        if ($folder !== null) {
             $file = base_path($folder . "/" . $filename);
-
-            if ($this->finder->exists($file))
-            {
+            if ($this->finder->exists($file)) {
                 return $file;
             }
         }

--- a/Modules/Workshop/Scaffold/Module/Generators/Generator.php
+++ b/Modules/Workshop/Scaffold/Module/Generators/Generator.php
@@ -83,6 +83,18 @@ abstract class Generator
      */
     protected function getStubPath($filename)
     {
+        $folder = $this->config->get('asgard.workshop.config.custom-stubs-folder');
+
+        if ($folder !== null)
+        {
+            $file = base_path($folder . "/" . $filename);
+
+            if ($this->finder->exists($file))
+            {
+                return $file;
+            }
+        }
+        
         return __DIR__ . "/../stubs/$filename";
     }
 


### PR DESCRIPTION
By this change we would be able to define a custom path where to store customized stubs. 
Only the changed stubs need to be stored in this folder.
If the file does not exist there, it will still be taken from Workshop Module stubs folder.
Config files needs to be re-published with force attribute.
When PR is accepted, I will also PR the Documentation.