### PR TITLE
Use standard ports in docker-compose + rename network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./docker/app
     image: asgardcms/app:latest
     ports:
-      - 8080:80
+      - 80:80
     volumes:
       - .:/var/www/html:cached
     networks:
@@ -24,7 +24,7 @@ services:
       context: ./docker/mysql
     image: asgardcms/mysql:latest
     ports:
-      - "4306:3306"
+      - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: asgardcms

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - .:/var/www/html:cached
     networks:
-      - ocnet
+      - asgard_net
   redis:
     build:
       context: ./docker/redis
@@ -17,7 +17,7 @@ services:
     volumes:
       - redisdata:/data
     networks:
-      - ocnet
+      - asgard_net
 
   mysql:
     build:
@@ -33,7 +33,7 @@ services:
     volumes:
       - mysqldata:/var/lib/mysql
     networks:
-      - ocnet
+      - asgard_net
 
   node:
     build:
@@ -50,5 +50,5 @@ volumes:
     driver: local
 
 networks:
-  ocnet:
+  asgard_net:
     driver: bridge


### PR DESCRIPTION
The goal of this PR is to restore the default/standards ports into the docker-compose.yml file, so that : 

- HTTP is exposed on port 80
- MySQL is exposed on port 3306

I also renamed the default network to add some Asgard swag 😎