### PR TITLE
Fix TokenMismatchException not being handled if `app.debug` is `false`

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -54,14 +54,14 @@ class Handler extends ExceptionHandler
             return parent::render($request, $e);
         }
 
-        if (config('app.debug') === false) {
-            return $this->handleExceptions($e);
-        }
-
         if ($e instanceof TokenMismatchException) {
             return redirect()->back()
-                ->withInput($request->except('password'))
-                ->withErrors(trans('core::core.error token mismatch'));
+                 ->withInput($request->except('password'))
+                 ->withErrors(trans('core::core.error token mismatch'));
+        }
+
+        if (config('app.debug') === false) {
+            return $this->handleExceptions($e);
         }
 
         return parent::render($request, $e);


### PR DESCRIPTION
I've been meaning to fix this for quite a long time...