### PR TITLE
Add missing `id` attribute to editor's textarea

### DIFF
--- a/Modules/Core/Resources/views/components/i18n/textarea.blade.php
+++ b/Modules/Core/Resources/views/components/i18n/textarea.blade.php
@@ -6,7 +6,7 @@
 
 <div class='{{ $errors->has("{$lang}.{$fieldName}") ? ' has-error' : '' }}'>
     {!! Form::label("{$lang}[{$fieldName}]", $labelName) !!}
-    <textarea class="{{ $editor->getEditorClass() }}" name="{{$lang}}[{{$fieldName}}]" rows="10" cols="80">{{ $slot }}</textarea>
+    <textarea class="{{ $editor->getEditorClass() }}" name="{{$lang}}[{{$fieldName}}]" id="{{$lang}}-{{$fieldName}}" rows="10" cols="80">{{ $slot }}</textarea>
     {!! $errors->first("{$lang}.{$fieldName}", '<span class="help-block">:message</span>') !!}
 </div>
 

--- a/Modules/Core/Resources/views/components/i18n/textarea.blade.php
+++ b/Modules/Core/Resources/views/components/i18n/textarea.blade.php
@@ -6,7 +6,7 @@
 
 <div class='{{ $errors->has("{$lang}.{$fieldName}") ? ' has-error' : '' }}'>
     {!! Form::label("{$lang}[{$fieldName}]", $labelName) !!}
-    <textarea class="{{ $editor->getEditorClass() }}" name="{{$lang}}[{{$fieldName}}]" id="{{$lang}}-{{$fieldName}}" rows="10" cols="80">{{ $slot }}</textarea>
+    <textarea class="{{ $editor->getEditorClass() }}" name="{{$lang}}[{{$fieldName}}]" id="{{$lang}}[{{$fieldName}}]" rows="10" cols="80">{{ $slot }}</textarea>
     {!! $errors->first("{$lang}.{$fieldName}", '<span class="help-block">:message</span>') !!}
 </div>
 

--- a/Modules/Core/Resources/views/components/textarea.blade.php
+++ b/Modules/Core/Resources/views/components/textarea.blade.php
@@ -6,7 +6,7 @@
 
 <div class='{{ $errors->has($fieldName) ? ' has-error' : '' }}'>
     {!! Form::label($fieldName, $labelName) !!}
-    <textarea class="{{ $editor->getEditorClass() }}" name="{{ $fieldName }}" rows="10" cols="80">{{ $slot }}</textarea>
+    <textarea class="{{ $editor->getEditorClass() }}" name="{{ $fieldName }}" id="{{ $fieldName }}" rows="10" cols="80">{{ $slot }}</textarea>
     {!! $errors->first($fieldName, '<span class="help-block">:message</span>') !!}
 </div>
 


### PR DESCRIPTION
Without this, it is impossible to add custom config to a single CKEditor instance since `CKEDITOR.replace()` uses the `id` of the field, not the name.