### PR TITLE
Make TranslationController slim

### DIFF
--- a/Modules/Core/macros.php
+++ b/Modules/Core/macros.php
@@ -345,3 +345,11 @@ Form::macro('normalSelect', function ($name, $title, ViewErrorBag $errors, array
 
     return new HtmlString($string);
 });
+
+Response::macro('csv', function ($file, $filename, $status = 200, $headers = []) {
+    return response($file, $status, array_merge([
+        'Content-Type' => 'application/csv',
+        'Content-Disposition' => "attachment; filename={$filename}",
+        'Pragma' => 'no-cache',
+    ], $headers));
+});

--- a/Modules/Translation/Http/Controllers/Admin/TranslationController.php
+++ b/Modules/Translation/Http/Controllers/Admin/TranslationController.php
@@ -53,11 +53,7 @@ class TranslationController extends AdminBaseController
 
     public function export(TranslationsExporter $exporter)
     {
-        return response()->make($exporter->export(), 200, [
-            'Content-Type' => 'application/csv',
-            'Content-Disposition' => "attachment; filename={$exporter->getFileName()}",
-            'Pragma' => 'no-cache',
-        ]);
+        return response()->csv($exporter->export(), $exporter->getFileName());
     }
 
     public function import(ImportTranslationsRequest $request, TranslationsImporter $importer)

--- a/Modules/Translation/Resources/lang/translation/en/translations.php
+++ b/Modules/Translation/Resources/lang/translation/en/translations.php
@@ -32,6 +32,7 @@ return [
     'event' => 'Event',
     'created' => 'Created',
     'edited' => 'Edited',
+    'revert history' => 'Revert History',
     'list resource' => 'List translations',
     'edit resource' => 'Edit translations',
     'import resource' => 'Import translations',

--- a/Modules/Translation/Resources/views/admin/translations/partials/revision.blade.php
+++ b/Modules/Translation/Resources/views/admin/translations/partials/revision.blade.php
@@ -1,0 +1,29 @@
+<tr>
+    <td>
+        @if ($history->oldValue() !== null)
+            {{ $history->oldValue() }}
+        @endif
+    </td>
+    <td>{{ $history->userResponsible()->present()->fullname() }}</td>
+    <td>
+        @if ($history->oldValue() === null)
+            {{ trans('translation::translations.created') }}
+        @else
+            {{ trans('translation::translations.edited') }}
+        @endif
+    </td>
+    <td>
+        <span data-toggle="tooltip" title="{{ $history->created_at }}">
+            {{ $history->created_at->diffForHumans() }}
+        </span>
+    </td>
+    <td>
+        @if ($history->oldValue() !== null)
+            <span data-toggle="tooltip" title="{{ trans('translation::translations.revert history') }}">
+                <a href="{{ route('admin.translation.translation.update', [$history->revisionable_id, 'oldValue' => $history->oldValue()]) }}">
+                    <i class="fa fa-history"></i>
+                </a>
+            </span>
+        @endif
+    </td>
+</tr>

--- a/Modules/Translation/Services/TranslationRevisions.php
+++ b/Modules/Translation/Services/TranslationRevisions.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Modules\Translation\Services;
+
+use Illuminate\Database\Eloquent\Collection;
+use Modules\Translation\Repositories\TranslationRepository;
+
+class TranslationRevisions
+{
+    /**
+     * @var TranslationRepository
+     */
+    private $translation;
+
+    /**
+     * @param TranslationRepository $translation
+     */
+    public function __construct(TranslationRepository $translation)
+    {
+        $this->translation = $translation;
+    }
+
+    /**
+     * Get revisions for the given key and locale.
+     *
+     * @param string $key
+     * @param string $locale
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function get($key, $locale)
+    {
+        $translation = $this->translation->findTranslationByKey($key);
+        $translation = $translation->translate($locale);
+
+        if ($translation === null) {
+            return response()->json(['<tr><td>' . trans('translation::translations.No Revisions yet') . '</td></tr>']);
+        }
+
+        return response()->json(
+            $this->formatRevisionHistory(
+                $translation->revisionHistory->reverse()
+            )
+        );
+    }
+
+    /**
+     * Format revision history.
+     *
+     * @param Collection $revisionHistory
+     * @return array
+     */
+    private function formatRevisionHistory(Collection $revisionHistory)
+    {
+        return $revisionHistory->reduce(function ($formattedHistory, $history) {
+            $formattedHistory[] = view('translation::admin.translations.partials.revision', compact('history'))->render();
+
+            return $formattedHistory;
+        });
+    }
+}


### PR DESCRIPTION
TranslationController is mixture of HTML code.

The controller is doing too much work for revisions and also heredoc inside the controller is messy as hell.

All revision formatting stuff is now abstracted into another class and revision template is moved into a blade partial.

Exporting data into CSV file is pretty common. so maybe it will be a good idea to make a macro for that. so that user can export CSV file in a fluent interface.