### PR TITLE
Bind current object to the dynamic relations closure

### DIFF
--- a/Modules/User/Entities/Sentinel/User.php
+++ b/Modules/User/Entities/Sentinel/User.php
@@ -114,7 +114,7 @@ class User extends EloquentUser implements UserInterface, AuthenticatableContrac
         if (config()->has($config)) {
             $function = config()->get($config);
 
-            return $function->bindTo($this);
+            return ($function->bindTo($this))();
         }
 
         #i: No relation found, return the call to parent (Eloquent) to handle it.

--- a/Modules/User/Entities/Sentinel/User.php
+++ b/Modules/User/Entities/Sentinel/User.php
@@ -113,8 +113,9 @@ class User extends EloquentUser implements UserInterface, AuthenticatableContrac
         #i: Relation method resolver
         if (config()->has($config)) {
             $function = config()->get($config);
-
-            return ($function->bindTo($this))();
+            $bound = $function->bindTo($this);
+            
+            return $bound();
         }
 
         #i: No relation found, return the call to parent (Eloquent) to handle it.

--- a/Modules/User/Entities/Sentinel/User.php
+++ b/Modules/User/Entities/Sentinel/User.php
@@ -114,7 +114,7 @@ class User extends EloquentUser implements UserInterface, AuthenticatableContrac
         if (config()->has($config)) {
             $function = config()->get($config);
 
-            return $function($this);
+            return $function->bindTo($this);
         }
 
         #i: No relation found, return the call to parent (Eloquent) to handle it.

--- a/config/asgard/user/config.php
+++ b/config/asgard/user/config.php
@@ -85,8 +85,8 @@ return [
      | Add relations that will be dynamically added to the User entity
      */
     'relations' => [
-//        'extension' => function ($self) {
-//            return $self->belongsTo(UserExtension::class, 'user_id', 'id')->first();
+//        'extension' => function () {
+//            return $this->belongsTo(UserExtension::class, 'user_id', 'id')->first();
 //        }
     ],
     /*


### PR DESCRIPTION
user can create dynamic relations without accepting the user object as a parameter.  now `$this` in closure will refer to the User object.

```php
'extension' => function () {
   return $this->belongsTo(UserExtension::class, 'user_id', 'id')->first();
}
```