### PR TITLE
Slug is required in page module

### DIFF
--- a/Modules/Page/Http/Requests/CreatePageRequest.php
+++ b/Modules/Page/Http/Requests/CreatePageRequest.php
@@ -19,6 +19,7 @@ class CreatePageRequest extends BaseFormRequest
     {
         return [
             'title' => 'required',
+            'slug' => 'required',
             'body' => 'required',
         ];
     }
@@ -40,6 +41,7 @@ class CreatePageRequest extends BaseFormRequest
     {
         return [
             'title.required' => trans('page::messages.title is required'),
+            'slug.required' => trans('page::messages.slug is required'),
             'body.required' => trans('page::messages.body is required'),
         ];
     }

--- a/Modules/Page/Http/Requests/UpdatePageRequest.php
+++ b/Modules/Page/Http/Requests/UpdatePageRequest.php
@@ -19,6 +19,7 @@ class UpdatePageRequest extends BaseFormRequest
     {
         return [
             'title' => 'required',
+            'slug' => 'required',
             'body' => 'required',
         ];
     }
@@ -40,6 +41,7 @@ class UpdatePageRequest extends BaseFormRequest
     {
         return [
             'title.required' => trans('page::messages.title is required'),
+            'slug.required' => trans('page::messages.slug is required'),
             'body.required' => trans('page::messages.body is required'),
         ];
     }

--- a/Modules/Translation/Resources/lang/page/de/messages.php
+++ b/Modules/Translation/Resources/lang/page/de/messages.php
@@ -8,6 +8,7 @@ return [
 
     'template is required' => 'Der Vorlagename ist erforderlich.',
     'title is required' => 'Der Titel ist erforderlich.',
+    'slug is required' => 'Der Slug ist erforderlich.',
     'body is required' => 'Der Inhalt ist erforderlich.',
     'only one homepage allowed' => 'Es kann nur eine Startseite definiert werden',
 ];

--- a/Modules/Translation/Resources/lang/page/en/messages.php
+++ b/Modules/Translation/Resources/lang/page/en/messages.php
@@ -8,6 +8,7 @@ return [
 
     'template is required' => 'The template name is required.',
     'title is required' => 'The title is required.',
+    'slug is required' => 'The slug is required.',
     'body is required' => 'The body is required.',
     'only one homepage allowed' => 'Only one homepage is allowed',
 ];

--- a/Modules/Translation/Resources/lang/page/fr/messages.php
+++ b/Modules/Translation/Resources/lang/page/fr/messages.php
@@ -8,6 +8,7 @@ return [
 
     'template is required' => 'Le nom de modèle de page est requis.',
     'title is required' => 'Le titre est requis.',
+    'slug is required' => 'Le slug est requis.',
     'body is required' => 'Le contenu est requis.',
     'only one homepage allowed' => 'Une seule page d\'accueil est permise.',
 ];

--- a/Modules/Translation/Resources/lang/page/nl/messages.php
+++ b/Modules/Translation/Resources/lang/page/nl/messages.php
@@ -8,6 +8,7 @@ return [
 
     'template is required' => 'De template naam is vereist.',
     'title is required' => 'De titel is vereist.',
+    'slug is required' => 'De slug is vereist.',
     'body is required' => 'De inhoud is vereist.',
     'only one homepage allowed' => 'Er kan maar één startpagina zijn',
 ];


### PR DESCRIPTION
The slug field is set as "NOT NULL" in the database, we have to make sure that the field is filled before creating/updating the page model.