### PR TITLE
Feature/refactor env file writer local

### DIFF
--- a/Modules/Core/Console/InstallCommand.php
+++ b/Modules/Core/Console/InstallCommand.php
@@ -57,6 +57,7 @@ class InstallCommand extends Command
 
         $success = $this->installer->stack([
             \Modules\Core\Console\Installers\Scripts\ProtectInstaller::class,
+            \Modules\Core\Console\Installers\Scripts\CreateEnvFile::class,
             \Modules\Core\Console\Installers\Scripts\ConfigureDatabase::class,
             \Modules\Core\Console\Installers\Scripts\SetAppKey::class,
             \Modules\Core\Console\Installers\Scripts\ConfigureUserProvider::class,

--- a/Modules/Core/Console/Installers/Scripts/ConfigureDatabase.php
+++ b/Modules/Core/Console/Installers/Scripts/ConfigureDatabase.php
@@ -48,15 +48,18 @@ class ConfigureDatabase implements SetupScript
 
         $connected = false;
 
-        while (! $connected) {
-            $driver = $this->askDatabaseDriver();
-            $host = $this->askDatabaseHost();
-            $port = $this->askDatabasePort($driver);
-            $name = $this->askDatabaseName();
-            $user = $this->askDatabaseUsername();
-            $password = $this->askDatabasePassword();
+        $vars = [];
 
-            $this->setLaravelConfiguration($driver, $host, $port, $name, $user, $password);
+        while (! $connected) {
+
+            $vars['db_driver'] = $this->askDatabaseDriver();
+            $vars['db_host'] = $this->askDatabaseHost();
+            $vars['db_port'] = $this->askDatabasePort($vars['db_driver']);
+            $vars['db_database'] = $this->askDatabaseName();
+            $vars['db_username'] = $this->askDatabaseUsername();
+            $vars['db_password'] = $this->askDatabasePassword();
+
+            $this->setLaravelConfiguration($vars);
 
             if ($this->databaseConnectionIsValid()) {
                 $connected = true;
@@ -65,7 +68,7 @@ class ConfigureDatabase implements SetupScript
             }
         }
 
-        $this->env->write($driver, $host, $port, $name, $user, $password);
+        $this->env->write($vars);
 
         $command->info('Database successfully configured');
     }
@@ -143,21 +146,19 @@ class ConfigureDatabase implements SetupScript
     }
 
     /**
-     * @param $driver
-     * @param $name
-     * @param $port
-     * @param $user
-     * @param $password
+     * @param array $vars
      */
-    protected function setLaravelConfiguration($driver, $host, $port, $name, $user, $password)
+    protected function setLaravelConfiguration($vars)
     {
-        $this->config['database.default'] = $driver;
-        $this->config['database.connections.' . $driver . '.host'] = $host;
-        $this->config['database.connections.' . $driver . '.port'] = $port;
-        $this->config['database.connections.' . $driver . '.database'] = $name;
-        $this->config['database.connections.' . $driver . '.username'] = $user;
-        $this->config['database.connections.' . $driver . '.password'] = $password;
+        $driver = $vars['db_driver'];
 
+        $this->config['database.default'] = $driver;
+        $this->config['database.connections.' . $driver . '.host'] = $vars['db_host'];
+        $this->config['database.connections.' . $driver . '.port'] = $vars['db_port'];
+        $this->config['database.connections.' . $driver . '.database'] = $vars['db_database'];
+        $this->config['database.connections.' . $driver . '.username'] = $vars['db_username'];
+        $this->config['database.connections.' . $driver . '.password'] = $vars['db_password'];
+        
         app(DatabaseManager::class)->purge($driver);
         app(ConnectionFactory::class)->make($this->config['database.connections.' . $driver], $driver);
     }

--- a/Modules/Core/Console/Installers/Scripts/CreateEnvFile.php
+++ b/Modules/Core/Console/Installers/Scripts/CreateEnvFile.php
@@ -6,17 +6,28 @@ use Illuminate\Console\Command;
 use Modules\Core\Console\Installers\SetupScript;
 use Modules\Core\Console\Installers\Writers\EnvFileWriter;
 
-class SetInstalledFlag implements SetupScript
+
+class CreateEnvFile implements SetupScript
 {
+     
     /**
      * @var EnvFileWriter
      */
     protected $env;
 
+    /**
+     * @param Config        $config
+     * @param EnvFileWriter $env
+     */
     public function __construct(EnvFileWriter $env)
     {
         $this->env = $env;
     }
+
+    /**
+     * @var Command
+     */
+    protected $command;
 
     /**
      * Fire the install script
@@ -25,14 +36,14 @@ class SetInstalledFlag implements SetupScript
      */
     public function fire(Command $command)
     {
-         
-        $vars = [];
+        $this->command = $command;
 
-        $vars['installed'] = 'true';
+        $this->env->create();
 
-        $this->env->write($vars);
-
-        $command->info('The application is now installed');
-
+        $command->info('Successfully created .env file');
     }
+
+     
+
 }
+

--- a/Modules/Core/Console/Installers/Writers/EnvFileWriter.php
+++ b/Modules/Core/Console/Installers/Writers/EnvFileWriter.php
@@ -12,15 +12,19 @@ class EnvFileWriter
     private $finder;
 
     /**
+     * Whitelist of variables in .env.example that can be written by the installer when it creates the .env file
+     *
      * @var array
      */
-    protected $search = [
-        'DB_CONNECTION=mysql',
-        'DB_HOST=127.0.0.1',
-        'DB_PORT=3306',
-        'DB_DATABASE=homestead',
-        'DB_USERNAME=homestead',
-        'DB_PASSWORD=secret',
+    protected $setable_variables = [
+        'db_driver' => 'DB_CONNECTION=mysql',
+        'db_host' => 'DB_HOST=127.0.0.1',
+        'db_port' => 'DB_PORT=3306',
+        'db_database' => 'DB_DATABASE=homestead',
+        'db_username' => 'DB_USERNAME=homestead',
+        'db_password' => 'DB_PASSWORD=secret',
+        'app_url' => 'APP_URL=http://localhost',
+        'installed' => 'INSTALLED=false',
     ];
 
     /**
@@ -42,29 +46,48 @@ class EnvFileWriter
     }
 
     /**
-     * @param $driver
-     * @param $host
-     * @param $port
-     * @param $name
-     * @param $username
-     * @param $password
+     * Create a new .env file using the contents of .env.example
+     *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @return void
      */
-    public function write($driver, $host, $port, $name, $username, $password)
+    public function create()
     {
         $environmentFile = $this->finder->get($this->template);
 
-        $replace = [
-            "DB_CONNECTION=$driver",
-            "DB_HOST=$host",
-            "DB_PORT=$port",
-            "DB_DATABASE=$name",
-            "DB_USERNAME=$username",
-            "DB_PASSWORD=$password",
-        ];
+        $this->finder->put($this->file, $environmentFile);
+    }
 
-        $newEnvironmentFile = str_replace($this->search, $replace, $environmentFile);
+    /**
+     * Update the .env file
+     *
+     * @param array $vars
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @return void
+     */
+    public function write($vars)
+    {
+        if (!empty($vars)) {
 
-        $this->finder->put($this->file, $newEnvironmentFile);
+            $environmentFile = $this->finder->get($this->file);
+
+            foreach ($vars as $key => $value) {
+
+                if (isset($this->setable_variables[$key])) {
+
+                    $env_var_name = explode('=', $this->setable_variables[$key])[0];
+
+                    $value = $env_var_name . '=' . $value;
+
+                    $environmentFile = str_replace($this->setable_variables[$key], $value, $environmentFile);
+
+                }
+
+            }
+
+            $this->finder->put($this->file, $environmentFile);
+
+        }
+
     }
 }


### PR DESCRIPTION
I have split up my Pull Request from 2.0 branch into smaller pieces and moved to 3.0 as requested. This is the 1st Pull Request.

Update EnvFileWriter so that it can be used to write any of the variables to the .env file not just the database connection variables. 

This means that in the future it would be possible to easily and consistently add prompts in the installer script for additional variables going forwards - specifically I think it would be useful to prompt for APP_URL as many people do not just use http://localhost but the MAIL or CACHE variables could also be added.

If we prompt for further variables then it makes sense to use a consistent method, therefore I have refactored EnvFileWriter. The other files have been updated to reflect this change and work consistently.

The .env file is now created by a new install script CreateEnvFile that calls EnvFileWriter