### PR TITLE
Update the message displayed while the admin user is created.

### DIFF
--- a/Modules/Core/Console/Installers/Scripts/UserProviders/ProviderInstaller.php
+++ b/Modules/Core/Console/Installers/Scripts/UserProviders/ProviderInstaller.php
@@ -190,7 +190,7 @@ abstract class ProviderInstaller implements SetupScript
         $user = $this->application->make(UserRepository::class)->createWithRolesFromCli($info, [1], true);
         $this->application->make(\Modules\User\Repositories\UserTokenRepository::class)->generateFor($user->id);
 
-        $this->command->info('Admin account created!');
+        $this->command->info('Please wait while the admin account is configured...');
     }
 
     /**


### PR DESCRIPTION
Setting up the admin user can take a while and it is not clear that the installer is still running, particularly if you are trying to do lots of things at once. A small change to the messaging would make  it clear  that the install process isn't quite finished.