### PR TITLE
Add additional install script to prompt for APP_URL

### DIFF
--- a/Modules/Core/Console/InstallCommand.php
+++ b/Modules/Core/Console/InstallCommand.php
@@ -59,6 +59,7 @@ class InstallCommand extends Command
             \Modules\Core\Console\Installers\Scripts\ProtectInstaller::class,
             \Modules\Core\Console\Installers\Scripts\CreateEnvFile::class,
             \Modules\Core\Console\Installers\Scripts\ConfigureDatabase::class,
+            \Modules\Core\Console\Installers\Scripts\ConfigureAppUrl::class,
             \Modules\Core\Console\Installers\Scripts\SetAppKey::class,
             \Modules\Core\Console\Installers\Scripts\ConfigureUserProvider::class,
             \Modules\Core\Console\Installers\Scripts\ModuleMigrator::class,

--- a/Modules/Core/Console/Installers/Scripts/ConfigureAppUrl.php
+++ b/Modules/Core/Console/Installers/Scripts/ConfigureAppUrl.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Modules\Core\Console\Installers\Scripts;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as Config;
+use Modules\Core\Console\Installers\SetupScript;
+use Modules\Core\Console\Installers\Writers\EnvFileWriter;
+
+class ConfigureAppUrl implements SetupScript
+{
+    /**
+     * @var
+     */
+    protected $config;
+
+    /**
+     * @var EnvFileWriter
+     */
+    protected $env;
+
+    /**
+     * @param Config        $config
+     * @param EnvFileWriter $env
+     */
+    public function __construct(Config $config, EnvFileWriter $env)
+    {
+        $this->config = $config;
+        $this->env = $env;
+    }
+
+    /**
+     * @var Command
+     */
+    protected $command;
+
+    /**
+     * Fire the install script
+     * @param  Command $command
+     * @return mixed
+     */
+    public function fire(Command $command)
+    {
+        $this->command = $command;
+
+        $vars = [];
+
+        $vars['app_url'] = $this->askAppUrl();
+
+        $this->setLaravelConfiguration($vars);
+
+        $this->env->write($vars);
+
+        $command->info('Application url successfully configured');
+    }
+
+    /**
+     * Ensure that the APP_URL is valid
+     *
+     * e.g. http://localhost, http://192.168.0.10, https://www.example.com etc.
+     *
+     * @return string
+     */
+    protected function askAppUrl()
+    {
+
+
+        do {
+            $str = $this->command->ask('Enter you application url (e.g. http://localhost, http://dev.example.com)', 'http://localhost');
+
+            if ($str == '' || (strpos($str, 'http://') !== 0 && strpos($str, 'https://') !== 0)) {
+
+                $this->command->error('A valid http:// or https:// url is required');
+
+                $str = false;
+
+            }
+
+        } while (!$str);
+
+
+        return $str;
+    }
+
+
+
+    /**
+     * @param $vars
+     */
+    protected function setLaravelConfiguration($vars)
+    {
+        $this->config['app.url'] = $vars['app_url'];
+         
+    }
+
+}


### PR DESCRIPTION
Add additional install script to prompt for APP_URL when gathering information to create the .env file

Give users the opportunity to set the APP_URL to something other than localhost, lots (most?) people run multiple sites in their local development servers.