### PR TITLE
Escaped the output of the @setting blade directive

### DIFF
--- a/Modules/Setting/Blade/SettingDirective.php
+++ b/Modules/Setting/Blade/SettingDirective.php
@@ -24,7 +24,7 @@ final class SettingDirective
     {
         $this->extractArguments($arguments);
 
-        return setting($this->settingName, $this->locale, $this->default);
+        return e(setting($this->settingName, $this->locale, $this->default));
     }
 
     /**


### PR DESCRIPTION
Currently the output of the `@setting` blade directive is unescaped.

This currently impacts the site meta description, if it is set to something containing a `"` it will break out of the meta description tag:

https://github.com/AsgardCms/Platform/blob/3.0/Themes/Flatly/views/layouts/master.blade.php#L6

With the `site-description` setting set to `A description containing "quotes" will break` will cause:

```
<meta name="description" content="@setting('core::site-description')" />
```

to become

```
<meta name="description" content="A description containing "quotes" will break" />
```