### PR TITLE
Explicitly used https to request the users Gravatar icon

### DIFF
--- a/Modules/User/Presenters/UserPresenter.php
+++ b/Modules/User/Presenters/UserPresenter.php
@@ -15,7 +15,7 @@ class UserPresenter extends Presenter
     {
         $email = md5($this->email);
 
-        return "//www.gravatar.com/avatar/$email?s=$size";
+        return "https://www.gravatar.com/avatar/$email?s=$size";
     }
 
     /**


### PR DESCRIPTION
The use of protocol relative URLs (`//example.org/alpha`) is now considered an anti-pattern.

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset. 

From https://www.paulirish.com/2010/the-protocol-relative-url/