### PR TITLE
Role Slug Unique Validation Fix

### DIFF
--- a/Modules/User/Http/Requests/RolesRequest.php
+++ b/Modules/User/Http/Requests/RolesRequest.php
@@ -8,9 +8,11 @@ class RolesRequest extends FormRequest
 {
     public function rules()
     {
+        $roleID = $this->route('roles');
+
         return [
             'name' => 'required',
-            'slug' => 'required|unique:roles,slug',
+            'slug' => 'required|unique:roles,slug,' . $roleID . ',id',
         ];
     }
 


### PR DESCRIPTION
The unique validation for role slugs was not ignoring the current role preventing roles from being updated