### PR TITLE
[2.0] Fix settings with falsey values not getting returned

### DIFF
--- a/Modules/Setting/Support/Settings.php
+++ b/Modules/Setting/Support/Settings.php
@@ -32,16 +32,16 @@ class Settings implements Setting
         $defaultFromConfig = $this->getDefaultFromConfigFor($name);
 
         $setting = $this->setting->findByName($name);
-        if (! $setting) {
+        if ($setting === null) {
             return is_null($default) ? $defaultFromConfig : $default;
         }
 
         if ($setting->isTranslatable) {
             if ($setting->hasTranslation($locale)) {
-                return empty($setting->translate($locale)->value) ? $defaultFromConfig : $setting->translate($locale)->value;
+                return trim($setting->translate($locale)->value) === '' ? $defaultFromConfig : $setting->translate($locale)->value;
             }
         } else {
-            return empty($setting->plainValue) ? $defaultFromConfig : $setting->plainValue;
+            return trim($setting->plainValue) === '' ? $defaultFromConfig : $setting->plainValue;
         }
 
         return $defaultFromConfig;

--- a/Modules/Setting/Tests/SettingsTest.php
+++ b/Modules/Setting/Tests/SettingsTest.php
@@ -58,6 +58,49 @@ class SettingsTest extends BaseSettingTest
     }
 
     /** @test */
+    public function it_returns_correctly_if_setting_is_falsey()
+    {
+        // Prepare
+        $data = [
+            'blog::posts-per-page' => 0,
+        ];
+
+        // Run
+        $this->settingRepository->createOrUpdate($data);
+
+        // Assert
+        $setting = $this->setting->get('blog::posts-per-page');
+        $this->assertEquals(0, $setting);
+    }
+
+    /** @test */
+    public function it_returns_correctly_if_setting_for_locale_is_falsey()
+    {
+        // Prepare
+        $this->app['config']->set('asgard.block.settings', [
+            'display-some-feature' => [
+                'description' => 'block::settings.display-some-feature',
+                'view' => 'text',
+                'translatable' => true,
+            ],
+        ]);
+
+        $data = [
+            'block::display-some-feature' => [
+                'en' => 0,
+                'fr' => 1,
+            ],
+        ];
+
+        // Run
+        $this->settingRepository->createOrUpdate($data);
+
+        // Assert
+        $this->assertEquals(0, $this->setting->get('block::display-some-feature', 'en'));
+        $this->assertEquals(1, $this->setting->get('block::display-some-feature', 'fr'));
+    }
+
+    /** @test */
     public function it_returns_a_default_value_if_no_setting_found()
     {
         // Prepare


### PR DESCRIPTION
This is the same as #435, but backported to Asgard 2