### PR TITLE
Add @resource DocBlock on API controllers

### DIFF
--- a/Modules/Media/Http/Controllers/Api/AllNestableFolderController.php
+++ b/Modules/Media/Http/Controllers/Api/AllNestableFolderController.php
@@ -5,6 +5,9 @@ namespace Modules\Media\Http\Controllers\Api;
 use Illuminate\Routing\Controller;
 use Modules\Media\Repositories\FolderRepository;
 
+/**
+ * @resource MediaFolder
+ */
 class AllNestableFolderController extends Controller
 {
     /**

--- a/Modules/Media/Http/Controllers/Api/BatchDestroyController.php
+++ b/Modules/Media/Http/Controllers/Api/BatchDestroyController.php
@@ -8,6 +8,9 @@ use Modules\Media\Image\Imagy;
 use Modules\Media\Repositories\FileRepository;
 use Modules\Media\Repositories\FolderRepository;
 
+/**
+ * @resource Media
+ */
 class BatchDestroyController extends Controller
 {
     /**

--- a/Modules/Media/Http/Controllers/Api/FolderBreadcrumbController.php
+++ b/Modules/Media/Http/Controllers/Api/FolderBreadcrumbController.php
@@ -6,6 +6,9 @@ use Illuminate\Routing\Controller;
 use Modules\Media\Entities\File;
 use Modules\Media\Repositories\FolderRepository;
 
+/**
+ * @resource MediaFolder
+ */
 class FolderBreadcrumbController extends Controller
 {
     /**

--- a/Modules/Media/Http/Controllers/Api/FolderController.php
+++ b/Modules/Media/Http/Controllers/Api/FolderController.php
@@ -7,6 +7,9 @@ use Modules\Media\Entities\File;
 use Modules\Media\Http\Requests\CreateFolderRequest;
 use Modules\Media\Repositories\FolderRepository;
 
+/**
+ * @resource MediaFolder
+ */
 class FolderController extends Controller
 {
     /**

--- a/Modules/Media/Http/Controllers/Api/MediaController.php
+++ b/Modules/Media/Http/Controllers/Api/MediaController.php
@@ -19,6 +19,9 @@ use Modules\Media\Services\FileService;
 use Modules\Media\Transformers\MediaTransformer;
 use Yajra\DataTables\Facades\DataTables;
 
+/**
+ * @resource Media
+ */
 class MediaController extends Controller
 {
     /**

--- a/Modules/Media/Http/Controllers/Api/MoveMediaController.php
+++ b/Modules/Media/Http/Controllers/Api/MoveMediaController.php
@@ -8,6 +8,9 @@ use Modules\Media\Repositories\FileRepository;
 use Modules\Media\Repositories\FolderRepository;
 use Modules\Media\Services\Movers\Mover;
 
+/**
+ * @resource Media
+ */
 class MoveMediaController extends Controller
 {
     /**

--- a/Modules/Menu/Http/Controllers/Api/MenuItemController.php
+++ b/Modules/Menu/Http/Controllers/Api/MenuItemController.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Response;
 use Modules\Menu\Repositories\MenuItemRepository;
 use Modules\Menu\Services\MenuOrdener;
 
+/**
+ * @resource MenuItem
+ */
 class MenuItemController extends Controller
 {
     /**

--- a/Modules/Page/Http/Controllers/Api/PageController.php
+++ b/Modules/Page/Http/Controllers/Api/PageController.php
@@ -11,6 +11,9 @@ use Modules\Page\Repositories\PageRepository;
 use Modules\Page\Transformers\FullPageTransformer;
 use Modules\Page\Transformers\PageTransformer;
 
+/**
+ * @resource Page
+ */
 class PageController extends Controller
 {
     /**

--- a/Modules/Page/Http/Controllers/Api/PageTemplatesController.php
+++ b/Modules/Page/Http/Controllers/Api/PageTemplatesController.php
@@ -7,6 +7,9 @@ use Illuminate\Routing\Controller;
 use Modules\Page\Services\FinderService;
 use Modules\Workshop\Manager\ThemeManager;
 
+/**
+ * @resource PageTemplates
+ */
 class PageTemplatesController extends Controller
 {
     /**

--- a/Modules/Page/Http/Controllers/Api/UpdatePageStatusController.php
+++ b/Modules/Page/Http/Controllers/Api/UpdatePageStatusController.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Modules\Page\Repositories\PageRepository;
 
+/**
+ * @resource Page
+ */
 class UpdatePageStatusController extends Controller
 {
     /**

--- a/Modules/Tag/Http/Controllers/Api/TagByNamespaceController.php
+++ b/Modules/Tag/Http/Controllers/Api/TagByNamespaceController.php
@@ -7,6 +7,9 @@ use Illuminate\Routing\Controller;
 use Modules\Tag\Repositories\TagRepository;
 use Modules\Tag\Transformers\TagTransformer;
 
+/**
+ * @resource Tag
+ */
 class TagByNamespaceController extends Controller
 {
     /**

--- a/Modules/Translation/Http/Controllers/Api/AllTranslationController.php
+++ b/Modules/Translation/Http/Controllers/Api/AllTranslationController.php
@@ -4,6 +4,9 @@ namespace Modules\Translation\Http\Controllers\Api;
 
 use Illuminate\Routing\Controller;
 
+/**
+ * @resource Translation
+ */
 class AllTranslationController extends Controller
 {
     public function __invoke()

--- a/Modules/Translation/Http/Controllers/Api/TranslationController.php
+++ b/Modules/Translation/Http/Controllers/Api/TranslationController.php
@@ -9,6 +9,9 @@ use Modules\Translation\Repositories\TranslationRepository;
 use Modules\Translation\Services\TranslationRevisions;
 use Modules\User\Traits\CanFindUserWithBearerToken;
 
+/**
+ * @resource Translation
+ */
 class TranslationController extends Controller
 {
     use CanFindUserWithBearerToken;

--- a/Modules/User/Http/Controllers/Api/ApiKeysController.php
+++ b/Modules/User/Http/Controllers/Api/ApiKeysController.php
@@ -8,6 +8,9 @@ use Modules\User\Entities\UserToken;
 use Modules\User\Repositories\UserTokenRepository;
 use Modules\User\Transformers\ApiKeysTransformer;
 
+/**
+ * @resource UserApiKeys
+ */
 class ApiKeysController extends Controller
 {
     /**

--- a/Modules/User/Http/Controllers/Api/PermissionsController.php
+++ b/Modules/User/Http/Controllers/Api/PermissionsController.php
@@ -5,6 +5,9 @@ namespace Modules\User\Http\Controllers\Api;
 use Illuminate\Routing\Controller;
 use Modules\User\Permissions\PermissionManager;
 
+/**
+ * @resource UserPermissions
+ */
 class PermissionsController extends Controller
 {
     /**

--- a/Modules/User/Http/Controllers/Api/ProfileController.php
+++ b/Modules/User/Http/Controllers/Api/ProfileController.php
@@ -8,6 +8,9 @@ use Modules\User\Http\Requests\UpdateProfileRequest;
 use Modules\User\Repositories\UserRepository;
 use Modules\User\Transformers\UserProfileTransformer;
 
+/**
+ * @resource UserProfile
+ */
 class ProfileController extends Controller
 {
     /**

--- a/Modules/User/Http/Controllers/Api/RoleController.php
+++ b/Modules/User/Http/Controllers/Api/RoleController.php
@@ -12,6 +12,9 @@ use Modules\User\Repositories\RoleRepository;
 use Modules\User\Transformers\FullRoleTransformer;
 use Modules\User\Transformers\RoleTransformer;
 
+/**
+ * @resource UserRole
+ */
 class RoleController extends Controller
 {
     /**

--- a/Modules/User/Http/Controllers/Api/UserController.php
+++ b/Modules/User/Http/Controllers/Api/UserController.php
@@ -14,6 +14,9 @@ use Modules\User\Repositories\UserRepository;
 use Modules\User\Transformers\FullUserTransformer;
 use Modules\User\Transformers\UserTransformer;
 
+/**
+ * @resource User
+ */
 class UserController extends Controller
 {
     /**

--- a/Modules/Workshop/Http/Controllers/Api/ModulesController.php
+++ b/Modules/Workshop/Http/Controllers/Api/ModulesController.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Artisan;
 use InvalidArgumentException;
 use Nwidart\Modules\Module;
 
+/**
+ * @resource WorkshopModules
+ */
 class ModulesController extends Controller
 {
     public function publishAssets(Module $module)

--- a/Modules/Workshop/Http/Controllers/Api/ThemeController.php
+++ b/Modules/Workshop/Http/Controllers/Api/ThemeController.php
@@ -7,6 +7,9 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Artisan;
 use InvalidArgumentException;
 
+/**
+ * @resource WorkshopTheme
+ */
 class ThemeController extends Controller
 {
     public function publishAssets(Theme $theme)


### PR DESCRIPTION
I am maintaining apidoc generator package [darron1217/laravel-apidoc-generator](https://github.com/darron1217/laravel-apidoc-generator)

With this package, we can create api doc like this
command: `php artisan api:generate --routePrefix="api/*" --noResponseCalls`
![image](https://user-images.githubusercontent.com/8064923/36069955-1c6f53ca-0f35-11e8-8580-eb21a7c44e4e.png)

This PR only adds DocBlock on each api controllers to group api urls :)