### PR TITLE
Fix issue#467 id() method checks null instead of false

### DIFF
--- a/Modules/User/Repositories/Sentinel/SentinelAuthentication.php
+++ b/Modules/User/Repositories/Sentinel/SentinelAuthentication.php
@@ -164,7 +164,7 @@ class SentinelAuthentication implements Authentication
     {
         $user = $this->user();
 
-        if ($user === null) {
+        if ($user === false) {
             return 0;
         }
 


### PR DESCRIPTION
Fix #467 

Fix error below
```
In SentinelAuthentication.php line 171:
Trying to get property of non-object
```