### PR TITLE
custom backend editor fix

### DIFF
--- a/Modules/Core/Assets/js/mixins/ActiveEditor.js
+++ b/Modules/Core/Assets/js/mixins/ActiveEditor.js
@@ -2,13 +2,13 @@ export default {
     methods: {
         getCurrentEditor() {
             const configuredEditor = window.AsgardCMS.editor;
+            if (configuredEditor === undefined || configuredEditor === 'ckeditor') {
+                return 'ckeditor';
+            }
             if (configuredEditor === 'simplemde') {
                 return 'markdown-editor';
             }
-            if (configuredEditor === 'ckeditor') {
-                return 'ckeditor';
-            }
-            return 'ckeditor';
+            return configuredEditor;
         },
     },
 };


### PR DESCRIPTION
The ActiveEditor.js doesn't refuse to load a custom editor anymore (Bugfix for #506).