### PR TITLE
Add settings directives

### DIFF
--- a/Modules/Setting/Blade/SettingDirective.php
+++ b/Modules/Setting/Blade/SettingDirective.php
@@ -28,6 +28,22 @@ final class SettingDirective
     }
 
     /**
+     * Check if a setting is set and is not empty
+     * @param array $arguments
+     * @return boolean
+     */
+    public function has($arguments)
+    {
+        $value = $this->show($arguments);
+
+        if (empty($value)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * @param array $arguments
      */
     private function extractArguments(array $arguments)

--- a/Modules/Setting/Providers/SettingServiceProvider.php
+++ b/Modules/Setting/Providers/SettingServiceProvider.php
@@ -94,8 +94,17 @@ class SettingServiceProvider extends ServiceProvider
         if (app()->environment() === 'testing') {
             return;
         }
+        
         $this->app['blade.compiler']->directive('setting', function ($value) {
             return "<?php echo SettingDirective::show([$value]); ?>";
+        });
+        
+        $this->app['blade.compiler']->directive('hasSetting', function($value) {
+            return "<?php if (SettingDirective::has([$value])) : ?>";
+        });
+        
+        $this->app['blade.compiler']->directive('endHasSetting', function() {
+            return "<?php endif; ?>";
         });
     }
 }


### PR DESCRIPTION
This PR makes adding the following directives

```
@hasSetting()
@endHasSetting
```
This allows to make conditional appearnce of blocks on the template based on the presence or absence of the setting.
Presence means != null and string != ''

Let me know if you need a test case to cover this new elements