### PR TITLE
Fix for #550

### DIFF
--- a/Modules/Core/Providers/CoreServiceProvider.php
+++ b/Modules/Core/Providers/CoreServiceProvider.php
@@ -349,7 +349,7 @@ class CoreServiceProvider extends ServiceProvider
      */
     private function onBackend()
     {
-        $url = app(Request::class)->url();
+        $url = app(Request::class)->path();
         if (str_contains($url, config('asgard.core.core.admin-prefix'))) {
             return true;
         }


### PR DESCRIPTION
Hello @nWidart,

I don't know if this is a feature or a bug, but I think we should only watch the request path when we are deciding if the user is on backend.
When we are watching the whole URL the subdomains are also involved but than we are getting error, because the system wants to include some admin JS.

Best regards,
David.

refs #550 