### PR TITLE
Fixed a bug that checked the last radio even if wasn't the right one

### DIFF
--- a/Modules/Setting/Resources/views/admin/fields/plain/radio.blade.php
+++ b/Modules/Setting/Resources/views/admin/fields/plain/radio.blade.php
@@ -5,7 +5,7 @@
                         name="{{ $settingName }}"
                         type="radio"
                         class="flat-blue"
-                        {{ isset($dbSettings[$settingName]) && (bool)$dbSettings[$settingName]->plainValue == $value ? 'checked' : '' }}
+                        {{ isset($dbSettings[$settingName]) && $dbSettings[$settingName]->plainValue == $value ? 'checked' : '' }}
                         value="{{ $value }}" />
                 {{ trans($optionName) }}
         </label>

--- a/Modules/Setting/Resources/views/admin/fields/translatable/radio.blade.php
+++ b/Modules/Setting/Resources/views/admin/fields/translatable/radio.blade.php
@@ -6,7 +6,7 @@
                         name="{{ $settingName . "[$lang]" }}"
                         type="radio"
                         class="flat-blue"
-                        {{ isset($dbSettings[$settingName]) && (bool)$oldValue == $value ? 'checked' : '' }}
+                        {{ isset($dbSettings[$settingName]) && $oldValue == $value ? 'checked' : '' }}
                         value="{{ $value }}" />
                 {{ trans($optionName) }}
         </label>


### PR DESCRIPTION
If you create a new module and a settings.php file with the following:

~~~
return [
    'default-optimizator' => [
        'description' => 'mediaoptimization::settings.fields.titles.default',
        'view' => 'radio',
        'translatable' => false,
        'options' => [
            'Test' => 'Test',
            'Dummy' => 'Dummy',
        ],
        'default' => 'Dummy',
    ]
];
~~~

you can see that if you save the first radio in the DB the value is correct but the view checked the wrong radio, usually the last one.  
For some reason the problem was the casting, removing it will work like a charm.