### PR TITLE
Fix the bug that prevent user to login or register to the site

### DIFF
--- a/Modules/Core/helpers.php
+++ b/Modules/Core/helpers.php
@@ -54,3 +54,13 @@ if (! function_exists('asgard_editor')) {
         return view('core::components.textarea-wrapper', compact('fieldName', 'labelName', 'content'));
     }
 }
+
+if (! function_exists('localize_route')) {
+    function localize_route($route, $locale = null)
+    {
+        $locale = $locale ? : app()->getLocale();
+
+        return str_replace(env('APP_URL'), rtrim(env('APP_URL'), '/') . '/' . $locale, route($route));
+
+    }
+}

--- a/Modules/User/Resources/views/public/login.blade.php
+++ b/Modules/User/Resources/views/public/login.blade.php
@@ -13,7 +13,8 @@
         <p class="login-box-msg">{{ trans('user::auth.sign in welcome message') }}</p>
         @include('partials.notifications')
 
-        {!! Form::open(['route' => 'login.post']) !!}
+        <form method="POST" action="{{localize_route('login.post')}}" accept-charset="UTF-8">
+            {{csrf_field()}}
             <div class="form-group has-feedback {{ $errors->has('email') ? ' has-error' : '' }}">
                 <input type="email" class="form-control" autofocus
                        name="email" placeholder="{{ trans('user::auth.email') }}" value="{{ old('email')}}">

--- a/Modules/User/Resources/views/public/register.blade.php
+++ b/Modules/User/Resources/views/public/register.blade.php
@@ -11,7 +11,9 @@
     <div class="register-box-body">
         <p class="login-box-msg">{{ trans('user::auth.register') }}</p>
         @include('partials.notifications')
-        {!! Form::open(['route' => 'register.post']) !!}
+
+        <form method="POST" action="{{localize_route('register.post')}}" accept-charset="UTF-8">
+            {{csrf_field()}}
             <div class="form-group has-feedback {{ $errors->has('email') ? ' has-error has-feedback' : '' }}">
                 <input type="email" name="email" class="form-control" autofocus
                        placeholder="{{ trans('user::auth.email') }}" value="{{ old('email') }}">

--- a/Modules/User/Resources/views/public/reset/begin.blade.php
+++ b/Modules/User/Resources/views/public/reset/begin.blade.php
@@ -13,7 +13,8 @@
         <p class="login-box-msg">{{ trans('user::auth.to reset password complete this form') }}</p>
         @include('partials.notifications')
 
-        {!! Form::open(['route' => 'reset.post']) !!}
+        <form method="POST" action="{{localize_route('reset.post')}}" accept-charset="UTF-8">
+                {{csrf_field()}}
             <div class="form-group has-feedback {{ $errors->has('email') ? ' has-error' : '' }}">
                 <input type="email" class="form-control" autofocus
                        name="email" placeholder="{{ trans('user::auth.email') }}" value="{{ old('email')}}">
@@ -28,7 +29,7 @@
                     </button>
                 </div>
             </div>
-        {!! Form::close() !!}
+        </form>
 
         <a href="{{ route('login') }}" class="text-center">{{ trans('user::auth.I remembered my password') }}</a>
     </div>


### PR DESCRIPTION
This fix is about this issue: https://github.com/AsgardCms/Platform/issues/581

In short the default `route` method do not consider the middleware about the localization so the action in the form are incorrect.  
For example for the login the url is just `auth/login` but the post method responds to `en/auth/login` so the route is never called.  

With this fix I have added a new helper function called `localize_route` that get the current url and add the current localization to create the correct url.  
I think that this is a general problem and in the blade views we should use always this function.

Hope this work for all of you, there is no frontend tests so I can't add tests for this commit, please try and let me know.