### PR TITLE
Fix german translation for page

### DIFF
--- a/Modules/Translation/Resources/lang/page/de/pages.php
+++ b/Modules/Translation/Resources/lang/page/de/pages.php
@@ -5,7 +5,7 @@ return [
     'create page' => 'Seite erstellen',
     'edit page' => 'Bearbeiten einer Seite',
     'name' => 'Name',
-    'slug' => 'Slug',
+    'status' => 'Status',
     'title' => 'Titel',
     'slug' => 'Slug',
     'meta_title' => 'Meta-Titel',


### PR DESCRIPTION
'slug' was double, 'status' was missing