### PR TITLE
Fix #583: `activated` vs `is_activated`

### DIFF
--- a/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
+++ b/Modules/User/Repositories/Sentinel/SentinelUserRepository.php
@@ -260,7 +260,7 @@ class SentinelUserRepository implements UserRepository
      */
     private function checkForManualActivation($user, array &$data)
     {
-        if (Activation::completed($user) && !$data['activated']) {
+        if (Activation::completed($user) && !$data['is_activated']) {
             return Activation::remove($user);
         }
 


### PR DESCRIPTION
Thank you to @chiragpipariya for his initial fix in #586.

Looks like this was partially solved by fa264a79f7af1fae97b104455452e52c30895f63 (and another earlier commit that I cannot find right this moment).