### PR TITLE
Server - For shared hosting where the installation is in root, we nee…

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine on
+    RewriteRule    ^$    public/    [L]
+    RewriteRule    (.*) public/$1    [L]
+</IfModule>


### PR DESCRIPTION
Many hostings not allow you to configure the root path, so this .htaccess redirect all request to the public folder where the web access of application is! 

See also this bug: 
- https://www.cvedetails.com/cve/CVE-2017-16894/
- https://twitter.com/finnwea/status/967709791442341888

And this article: 
- https://medium.com/@marcelpociot/protect-your-env-files-387b4f66d809