### PR TITLE
Adds Roave Vulnerability Checker Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "orchestra/testbench": "^3.5",
         "league/flysystem-aws-s3-v3": "^1.0",
         "league/commonmark": "^0.15.4",
-        "predis/predis": "^1.1"
+        "predis/predis": "^1.1",
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
This PR adds `roave/security-advisories` as a dev dependency to help mitigate vulnerable code from being installed.