### PR TITLE
Use Env When Defining The Hashbang

### DIFF
--- a/dcp
+++ b/dcp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 COMPOSE="docker-compose"
 


### PR DESCRIPTION
This PR replaces the hardcoded path to the bash executable with a call to `/usr/bin/env` allowing the user to use whatever version of bash they want.

See here for more details why this is a good idea: https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash#16365367