### PR TITLE
Prevent nestable collection removing menu items

### DIFF
--- a/Modules/Menu/Repositories/Eloquent/EloquentMenuItemRepository.php
+++ b/Modules/Menu/Repositories/Eloquent/EloquentMenuItemRepository.php
@@ -113,7 +113,7 @@ class EloquentMenuItemRepository extends EloquentBaseRepository implements MenuI
     {
         $items = $this->rootsForMenu($menuId);
 
-        return $items->nest();
+        return $items->noCleaning()->nest();
     }
 
     /**


### PR DESCRIPTION
Because the `root` menu item is not active, Nestable Collection was removing all the menu items. Why this only showed up on the upgrade to Laravel 5.7, I have no idea…