### PR TITLE
Add possibility to define some options on number field

### DIFF
--- a/Modules/Setting/Resources/views/admin/fields/plain/number.blade.php
+++ b/Modules/Setting/Resources/views/admin/fields/plain/number.blade.php
@@ -1,9 +1,16 @@
-<?php $defaultValue = isset($moduleInfo['default']) ? $moduleInfo['default']: ''; ?>
+<?php
+    $defaultValue = isset($moduleInfo['default']) ? $moduleInfo['default']: '';
+    $defaultOptions = [
+        'class' => 'form-control',
+        'placeholder' => trans($moduleInfo['description'])
+    ];
+    $options = array_merge($defaultOptions, isset($moduleInfo['options']) ? $moduleInfo['options'] : []);
+?>
 <div class='form-group'>
     {!! Form::label($settingName, trans($moduleInfo['description'])) !!}
     <?php if (isset($dbSettings[$settingName]) && $dbSettings[$settingName]->plainValue !== null): ?>
-        {!! Form::number($settingName, old($settingName, $dbSettings[$settingName]->plainValue) ?: $defaultValue, ['class' => 'form-control', 'placeholder' => trans($moduleInfo['description'])]) !!}
+        {!! Form::number($settingName, old($settingName, $dbSettings[$settingName]->plainValue) ?: $defaultValue, $options) !!}
     <?php else: ?>
-        {!! Form::number($settingName, old($settingName, $defaultValue), ['class' => 'form-control', 'placeholder' => trans($moduleInfo['description'])]) !!}
+        {!! Form::number($settingName, old($settingName, $defaultValue), $options) !!}
     <?php endif; ?>
 </div>

--- a/Modules/Setting/Resources/views/admin/fields/translatable/number.blade.php
+++ b/Modules/Setting/Resources/views/admin/fields/translatable/number.blade.php
@@ -1,10 +1,17 @@
-<?php $defaultValue = isset($moduleInfo['default']) ? $moduleInfo['default']: ''; ?>
+<?php
+    $defaultValue = isset($moduleInfo['default']) ? $moduleInfo['default']: '';
+    $defaultOptions = [
+        'class' => 'form-control',
+        'placeholder' => trans($moduleInfo['description'])
+    ];
+    $options = array_merge($defaultOptions, isset($moduleInfo['options']) ? $moduleInfo['options'] : []);
+?>
 <div class='form-group'>
     {!! Form::label($settingName . "[$lang]", trans($moduleInfo['description'])) !!}
     <?php if (isset($dbSettings[$settingName])): ?>
         <?php $value = $dbSettings[$settingName]->hasTranslation($lang) ? $dbSettings[$settingName]->translate($lang)->value : $defaultValue; ?>
-        {!! Form::number($settingName . "[$lang]", old($settingName . "[$lang]", $value), ['class' => 'form-control', 'placeholder' => trans($moduleInfo['description'])]) !!}
+        {!! Form::number($settingName . "[$lang]", old($settingName . "[$lang]", $value), $options) !!}
     <?php else: ?>
-        {!! Form::number($settingName . "[$lang]", old($settingName . "[$lang]", $defaultValue), ['class' => 'form-control', 'placeholder' => trans($moduleInfo['description'])]) !!}
+        {!! Form::number($settingName . "[$lang]", old($settingName . "[$lang]", $defaultValue), $options) !!}
     <?php endif; ?>
 </div>


### PR DESCRIPTION
In the number fields there is no possibility to define `min`, `max` or `step` because the options are hard coded.  
I have added default options array that wil lbe merged with the options added by user.  
In this way the user can add a `options` array to define what he need.

For example, lets assume we have this options settings:

```
 'invoice_default_tax' => [
        'description' => trans('invoice::settings.form.default_tax'),
        'view' => 'number',
        'translatable' => false,
        'options' => [
            'min' => 10,
            'max' => 30,
            'step' => 0.1
        ]
    ],
```

it will be merged with the default and now in the setting the input is much more useful.

Please review if it works, the same logic can be applied to the other fields