### PR TITLE
Possibile fix for alternate variable not set in page

### DIFF
--- a/Modules/Core/Http/Controllers/BasePublicController.php
+++ b/Modules/Core/Http/Controllers/BasePublicController.php
@@ -4,6 +4,10 @@ namespace Modules\Core\Http\Controllers;
 
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\View;
+use Modules\Core\Foundation\Asset\Manager\AssetManager;
+use Modules\Core\Foundation\Asset\Pipeline\AssetPipeline;
+use Modules\Core\Foundation\Asset\Types\AssetTypeFactory;
 use Modules\User\Contracts\Authentication;
 
 abstract class BasePublicController extends Controller
@@ -14,9 +18,67 @@ abstract class BasePublicController extends Controller
     protected $auth;
     public $locale;
 
+    /**
+     * @var array Alternate URLs
+     */
+    public $alternateUrls = [];
+
+    /**
+     * @var AssetManager
+     */
+    protected $assetManager;
+    /**
+     * @var AssetPipeline
+     */
+    protected $assetPipeline;
+    /**
+     * @var AssetTypeFactory
+     */
+    protected $assetFactory;
+
     public function __construct()
     {
         $this->locale = App::getLocale();
         $this->auth = app(Authentication::class);
+
+        $this->assetManager = app(AssetManager::class);
+        $this->assetPipeline = app(AssetPipeline::class);
+        $this->assetFactory = app(AssetTypeFactory::class);
+
+        $this->addAssets();
+        $this->requireDefaultAssets();
+        view()->share('alternate', $this->alternateUrls);
+    }
+
+    /**
+     * Add the assets from the config file on the asset manager.
+     */
+    private function addAssets()
+    {
+        foreach (config('asgard.core.core.frontend-assets') as $assetName => $path) {
+            $path = $this->assetFactory->make($path)->url();
+            $this->assetManager->addAsset($assetName, $path);
+        }
+    }
+
+    /**
+     * Require the default assets from config file on the asset pipeline.
+     */
+    private function requireDefaultAssets()
+    {
+        $this->assetPipeline->requireCss(config('asgard.core.core.frontend-required-assets.css'));
+        $this->assetPipeline->requireJs(config('asgard.core.core.frontend-required-assets.js'));
+    }
+
+    /**
+     * Add alternate URLs to main array and inject it to the page
+     *
+     * @param array $alternateUrls
+     * @return void
+     */
+    protected function addAlternateUrls(array $alternateUrls)
+    {
+        $this->alternateUrls = array_merge($this->alternateUrls, $alternateUrls);
+        view()->share('alternate', $this->alternateUrls);
     }
 }

--- a/Modules/Core/Http/Controllers/BasePublicController.php
+++ b/Modules/Core/Http/Controllers/BasePublicController.php
@@ -4,10 +4,6 @@ namespace Modules\Core\Http\Controllers;
 
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\View;
-use Modules\Core\Foundation\Asset\Manager\AssetManager;
-use Modules\Core\Foundation\Asset\Pipeline\AssetPipeline;
-use Modules\Core\Foundation\Asset\Types\AssetTypeFactory;
 use Modules\User\Contracts\Authentication;
 
 abstract class BasePublicController extends Controller
@@ -17,57 +13,13 @@ abstract class BasePublicController extends Controller
      */
     protected $auth;
     public $locale;
-
-    /**
-     * @var array Alternate URLs
-     */
     public $alternateUrls = [];
-
-    /**
-     * @var AssetManager
-     */
-    protected $assetManager;
-    /**
-     * @var AssetPipeline
-     */
-    protected $assetPipeline;
-    /**
-     * @var AssetTypeFactory
-     */
-    protected $assetFactory;
 
     public function __construct()
     {
         $this->locale = App::getLocale();
         $this->auth = app(Authentication::class);
-
-        $this->assetManager = app(AssetManager::class);
-        $this->assetPipeline = app(AssetPipeline::class);
-        $this->assetFactory = app(AssetTypeFactory::class);
-
-        $this->addAssets();
-        $this->requireDefaultAssets();
         view()->share('alternate', $this->alternateUrls);
-    }
-
-    /**
-     * Add the assets from the config file on the asset manager.
-     */
-    private function addAssets()
-    {
-        foreach (config('asgard.core.core.frontend-assets') as $assetName => $path) {
-            $path = $this->assetFactory->make($path)->url();
-            $this->assetManager->addAsset($assetName, $path);
-        }
-    }
-
-    /**
-     * Require the default assets from config file on the asset pipeline.
-     */
-    private function requireDefaultAssets()
-    {
-        $this->assetPipeline->requireCss(config('asgard.core.core.frontend-required-assets.css'));
-        $this->assetPipeline->requireJs(config('asgard.core.core.frontend-required-assets.js'));
     }
 
     /**

--- a/Modules/Page/Http/Controllers/PublicController.php
+++ b/Modules/Page/Http/Controllers/PublicController.php
@@ -19,16 +19,17 @@ class PublicController extends BasePublicController
      */
     private $app;
 
+    private $disabledPage = false;
+
     public function __construct(PageRepository $page, Application $app)
     {
         parent::__construct();
         $this->page = $page;
-        $this->app  = $app;
+        $this->app = $app;
     }
 
     /**
      * @param $slug
-     *
      * @return \Illuminate\View\View
      */
     public function uri($slug)
@@ -39,6 +40,7 @@ class PublicController extends BasePublicController
 
         $currentTranslatedPage = $page->getTranslation(locale());
         if ($slug !== $currentTranslatedPage->slug) {
+
             return redirect()->to($currentTranslatedPage->locale . '/' . $currentTranslatedPage->slug, 301);
         }
 
@@ -68,9 +70,7 @@ class PublicController extends BasePublicController
     /**
      * Find a page for the given slug.
      * The slug can be a 'composed' slug via the Menu
-     *
      * @param string $slug
-     *
      * @return Page
      */
     private function findPageForSlug($slug)
@@ -87,9 +87,7 @@ class PublicController extends BasePublicController
     /**
      * Return the template for the given page
      * or the default template if none found
-     *
      * @param $page
-     *
      * @return string
      */
     private function getTemplateForPage($page)
@@ -98,13 +96,12 @@ class PublicController extends BasePublicController
     }
 
     /**
-     * Throw a 404 error page if the given page is not found
-     *
+     * Throw a 404 error page if the given page is not found or draft
      * @param $page
      */
     private function throw404IfNotFound($page)
     {
-        if (is_null($page)) {
+        if (null === $page || $page->status === $this->disabledPage) {
             $this->app->abort('404');
         }
     }
@@ -116,7 +113,7 @@ class PublicController extends BasePublicController
      *
      * @return array
      */
-    private function getAlternateData($page)
+    private function getAlternateMetaData($page)
     {
         $translations = $page->getTranslationsArray();
 

--- a/Modules/Page/Http/Controllers/PublicController.php
+++ b/Modules/Page/Http/Controllers/PublicController.php
@@ -19,17 +19,16 @@ class PublicController extends BasePublicController
      */
     private $app;
 
-    private $disabledPage = false;
-
     public function __construct(PageRepository $page, Application $app)
     {
         parent::__construct();
         $this->page = $page;
-        $this->app = $app;
+        $this->app  = $app;
     }
 
     /**
      * @param $slug
+     *
      * @return \Illuminate\View\View
      */
     public function uri($slug)
@@ -40,15 +39,14 @@ class PublicController extends BasePublicController
 
         $currentTranslatedPage = $page->getTranslation(locale());
         if ($slug !== $currentTranslatedPage->slug) {
-
             return redirect()->to($currentTranslatedPage->locale . '/' . $currentTranslatedPage->slug, 301);
         }
 
         $template = $this->getTemplateForPage($page);
 
-        $alternate = $this->getAlternateMetaData($page);
+        $this->addAlternateUrls($this->getAlternateData($page));
 
-        return view($template, compact('page', 'alternate'));
+        return view($template, compact('page'));
     }
 
     /**
@@ -62,15 +60,17 @@ class PublicController extends BasePublicController
 
         $template = $this->getTemplateForPage($page);
 
-        $alternate = $this->getAlternateMetaData($page);
+        $this->addAlternateUrls($this->getAlternateData($page));
 
-        return view($template, compact('page', 'alternate'));
+        return view($template, compact('page'));
     }
 
     /**
      * Find a page for the given slug.
      * The slug can be a 'composed' slug via the Menu
+     *
      * @param string $slug
+     *
      * @return Page
      */
     private function findPageForSlug($slug)
@@ -87,7 +87,9 @@ class PublicController extends BasePublicController
     /**
      * Return the template for the given page
      * or the default template if none found
+     *
      * @param $page
+     *
      * @return string
      */
     private function getTemplateForPage($page)
@@ -96,12 +98,13 @@ class PublicController extends BasePublicController
     }
 
     /**
-     * Throw a 404 error page if the given page is not found or draft
+     * Throw a 404 error page if the given page is not found
+     *
      * @param $page
      */
     private function throw404IfNotFound($page)
     {
-        if (null === $page || $page->status === $this->disabledPage) {
+        if (is_null($page)) {
             $this->app->abort('404');
         }
     }
@@ -113,7 +116,7 @@ class PublicController extends BasePublicController
      *
      * @return array
      */
-    private function getAlternateMetaData($page)
+    private function getAlternateData($page)
     {
         $translations = $page->getTranslationsArray();
 


### PR DESCRIPTION
I have added a new method in the BasePublicController to allow all the PublicController to add alternate urls.
By default the $alternateUrls array is empty and is shared in the view with the share method.

Don't know if is the best way, please check it

Refer: #631