### PR TITLE
Possibile fix for alternate variable not set in page

### DIFF
--- a/Modules/Core/Http/Controllers/BasePublicController.php
+++ b/Modules/Core/Http/Controllers/BasePublicController.php
@@ -13,10 +13,25 @@ abstract class BasePublicController extends Controller
      */
     protected $auth;
     public $locale;
+    public $alternateUrls = [];
 
     public function __construct()
     {
         $this->locale = App::getLocale();
         $this->auth = app(Authentication::class);
+        view()->share('alternate', $this->alternateUrls);
     }
+
+    /**
+     * Add alternate URLs to main array and inject it to the page
+     *
+     * @param array $alternateUrls
+     * @return void
+     */
+    protected function addAlternateUrls(array $alternateUrls)
+    {
+        $this->alternateUrls = array_merge($this->alternateUrls, $alternateUrls);
+        view()->share('alternate', $this->alternateUrls);
+    }
+}
 }

--- a/Modules/Page/Http/Controllers/PublicController.php
+++ b/Modules/Page/Http/Controllers/PublicController.php
@@ -46,9 +46,9 @@ class PublicController extends BasePublicController
 
         $template = $this->getTemplateForPage($page);
 
-        $alternate = $this->getAlternateMetaData($page);
+        $this->addAlternateUrls($this->getAlternateMetaData($page));
 
-        return view($template, compact('page', 'alternate'));
+        return view($template, compact('page'));
     }
 
     /**
@@ -62,9 +62,9 @@ class PublicController extends BasePublicController
 
         $template = $this->getTemplateForPage($page);
 
-        $alternate = $this->getAlternateMetaData($page);
+        $this->addAlternateUrls($this->getAlternateMetaData($page));
 
-        return view($template, compact('page', 'alternate'));
+        return view($template, compact('page'));
     }
 
     /**


### PR DESCRIPTION
I have added a new method in the BasePublicController to allow all the PublicController to add alternate urls.
By default the $alternateUrls array is empty and is shared in the view with the share method.

Don't know if is the best way, please check it

Refer: #631 