### PR TITLE
Added return type and used getUser function instead of check

### DIFF
--- a/Modules/User/Repositories/Sentinel/SentinelAuthentication.php
+++ b/Modules/User/Repositories/Sentinel/SentinelAuthentication.php
@@ -123,7 +123,7 @@ class SentinelAuthentication implements Authentication
      * @param $permission
      * @return bool
      */
-    public function hasAccess($permission)
+    public function hasAccess($permission) : bool
     {
         if (! Sentinel::check()) {
             return false;
@@ -136,7 +136,7 @@ class SentinelAuthentication implements Authentication
      * Check if the user is logged in
      * @return bool
      */
-    public function check()
+    public function check() : bool
     {
         $user = Sentinel::check();
 
@@ -153,14 +153,14 @@ class SentinelAuthentication implements Authentication
      */
     public function user()
     {
-        return Sentinel::check();
+        return Sentinel::getUser();
     }
 
     /**
      * Get the ID for the currently authenticated user
      * @return int
      */
-    public function id()
+    public function id() : int
     {
         $user = $this->user();
 


### PR DESCRIPTION
I have edited the `Modules/User/Repositories/Sentinel/SentinelAuthentication.php` file adding some return types and I have used the `getUser` method instead of `check` method to retrieve the user.  
Reading Sentinel documentation looks like that both of them return the user object but I think that getUser is much more readable and understandable

Any tought?