### PR TITLE
Prevent the bootWidgets() from being executed before middlewares checks

### DIFF
--- a/Modules/Dashboard/Http/Controllers/Admin/DashboardController.php
+++ b/Modules/Dashboard/Http/Controllers/Admin/DashboardController.php
@@ -28,9 +28,14 @@ class DashboardController extends AdminBaseController
     public function __construct(RepositoryInterface $modules, WidgetRepository $widget, Authentication $auth)
     {
         parent::__construct();
-        $this->bootWidgets($modules);
         $this->widget = $widget;
         $this->auth = $auth;
+
+        $this->middleware(function ($request, $next) use ($modules) {
+            $this->bootWidgets($modules);
+
+            return $next($request);
+        });
     }
 
     /**


### PR DESCRIPTION
This PR is about the issue pointed out on slack, here the references: https://asgardcms.slack.com/archives/C043NPXKQ/p1541563026016400

Since the construct is executed before the middlewares, this will prevent the bootWidgets() from being executed before the permissions checks