### PR TITLE
Redirect the user to the login page if activation links fails

### DIFF
--- a/Modules/Dashboard/Http/Controllers/Admin/DashboardController.php
+++ b/Modules/Dashboard/Http/Controllers/Admin/DashboardController.php
@@ -28,9 +28,14 @@ class DashboardController extends AdminBaseController
     public function __construct(RepositoryInterface $modules, WidgetRepository $widget, Authentication $auth)
     {
         parent::__construct();
-        $this->bootWidgets($modules);
         $this->widget = $widget;
         $this->auth = $auth;
+
+        $this->middleware(function ($request, $next) use ($modules) {
+            $this->bootWidgets($modules);
+
+            return $next($request);
+        });
     }
 
     /**

--- a/Modules/User/Http/Controllers/AuthController.php
+++ b/Modules/User/Http/Controllers/AuthController.php
@@ -73,7 +73,7 @@ class AuthController extends BasePublicController
                 ->withSuccess(trans('user::messages.account activated you can now login'));
         }
 
-        return redirect()->route('register')
+        return redirect()->route('login')
             ->withError(trans('user::messages.there was an error with the activation'));
     }
 


### PR DESCRIPTION
Since you can create user manually even if you close the registrations route the activation method can't redirect user to the registration page if the activation fails.   
This will redirect the user to the login page with the error message, if a user has the activation links there is no needs to redirect it to the register page, we can assume that a registration has already been placed by it or an admin.

This refers to the slack issue: https://asgardcms.slack.com/archives/C043NPXKQ/p1541472151008300