### PR TITLE
Allow CKEditor custom config to work in Vue component

### DIFF
--- a/Modules/Core/Assets/js/components/CkEditor.vue
+++ b/Modules/Core/Assets/js/components/CkEditor.vue
@@ -5,7 +5,6 @@
         :value="value"
         :types="types"
         :config="config"
-        class="ckeditor"
     ></textarea>
 </template>
 

--- a/Modules/Core/Assets/js/components/CkEditor.vue
+++ b/Modules/Core/Assets/js/components/CkEditor.vue
@@ -1,13 +1,12 @@
 <template>
-    <div class="ckeditor">
-        <textarea
-                :name="name"
-                :id="id"
-                :value="value"
-                :types="types"
-                :config="config">
-        </textarea>
-    </div>
+    <textarea
+        :name="name"
+        :id="id"
+        :value="value"
+        :types="types"
+        :config="config"
+        class="ckeditor"
+    ></textarea>
 </template>
 
 <script>
@@ -18,77 +17,87 @@
         props: {
             name: {
                 type: String,
-                default: () => `editor-${++inc}`
+                default: () => `editor-${++inc}`,
             },
             value: {
-                type: String
+                type: String,
+                default: () => '',
             },
             id: {
                 type: String,
-                default: () => `editor-${inc}`
+                default: () => `editor-${inc}`,
             },
             types: {
                 type: String,
-                default: () => `classic`
+                default: () => 'classic',
             },
             config: {
                 type: Object,
-                default: () => {}
-            }
+                default: () => {
+                    if (window.AsgardCMS.ckeditorCustomConfig !== '') {
+                        return {
+                            customConfig: window.AsgardCMS.ckeditorCustomConfig,
+                        };
+                    }
+
+                    return undefined;
+                },
+            },
         },
-        data () {
-            return { destroyed: false }
+        data() {
+            return { destroyed: false };
         },
         computed: {
-            instance () {
-                return CKEDITOR.instances[this.id]
-            }
+            instance() {
+                return CKEDITOR.instances[this.id];
+            },
         },
         watch: {
-            value (val) {
+            value(val) {
                 if (this.instance) {
-                    let html = this.instance.getData();
+                    const html = this.instance.getData();
                     if (val !== html) {
                         this.instance.setData(val);
                     }
                 }
-            }
+            },
         },
-        mounted () {
+        mounted() {
             if (typeof CKEDITOR === 'undefined') {
-                console.log('CKEDITOR is missing (http://ckeditor.com/)')
+                console.log('CKEDITOR is missing (http://ckeditor.com/)');
             } else {
                 if (this.types === 'inline') {
-                    CKEDITOR.inline(this.id, this.config)
+                    CKEDITOR.inline(this.id, this.config);
                 } else {
-                    CKEDITOR.replace(this.id, this.config)
+                    CKEDITOR.replace(this.id, this.config);
                 }
                 this.instance.on('change', () => {
-                    let html = this.instance.getData()
+                    const html = this.instance.getData();
                     if (html !== this.value) {
-                        this.$emit('input', html)
-                        this.$emit('update:value', html)
+                        this.$emit('input', html);
+                        this.$emit('update:value', html);
                     }
-                })
+                });
                 this.instance.on('blur', () => {
-                    this.$emit('blur', this.instance)
-                })
+                    this.$emit('blur', this.instance);
+                });
                 this.instance.on('focus', () => {
-                    this.$emit('focus', this.instance)
-                })
+                    this.$emit('focus', this.instance);
+                });
             }
         },
-        beforeDestroy () {
+        beforeDestroy() {
             if (!this.destroyed) {
-                this.instance.focusManager.blur(true)
-                this.instance.removeAllListeners()
+                this.instance.focusManager.blur(true);
+                this.instance.removeAllListeners();
                 try {
-                    this.instance.destroy()
-                } catch (e) { }
-                this.destroyed = true
+                    this.instance.destroy();
+                } catch (e) {
+                }
+                this.destroyed = true;
             }
-        }
-    }
+        },
+    };
 </script>
 <style>
     .ckeditor::after {

--- a/Themes/Adminlte/views/layouts/master.blade.php
+++ b/Themes/Adminlte/views/layouts/master.blade.php
@@ -81,6 +81,7 @@
         locales: {!! json_encode(LaravelLocalization::getSupportedLocales()) !!},
         currentLocale: '{{ locale() }}',
         editor: '{{ $activeEditor }}',
+        ckeditorCustomConfig: '{{ config('asgard.core.core.ckeditor-config-file-path', '') }}',
         adminPrefix: '{{ config('asgard.core.core.admin-prefix') }}',
         hideDefaultLocaleInURL: '{{ config('laravellocalization.hideDefaultLocaleInURL') }}',
         filesystem: '{{ config('asgard.media.config.filesystem') }}'


### PR DESCRIPTION
Right now, there is no config applied, unless you manually pass it via the `config` param. This sets the default (if the `config` param was not supplied) to use the custom CKEditor config file, if there is one.