### PR TITLE
Rename the label for the status checkbox to make it less ambiguous

### DIFF
--- a/Modules/Page/Assets/js/components/PageForm.vue
+++ b/Modules/Page/Assets/js/components/PageForm.vue
@@ -54,7 +54,7 @@
 
                                     <el-form-item :label="trans('pages.status')"
                                                   :class="{'el-form-item is-error': form.errors.has(locale + '.status') }">
-                                        <el-checkbox v-model="page[locale].status">{{ trans('pages.status') }}</el-checkbox>
+                                        <el-checkbox v-model="page[locale].status">{{ trans('pages.live') }}</el-checkbox>
                                         <div class="el-form-item__error" v-if="form.errors.has(locale + '.status')"
                                              v-text="form.errors.first(locale + '.status')"></div>
                                     </el-form-item>

--- a/Modules/Translation/Resources/lang/page/en/pages.php
+++ b/Modules/Translation/Resources/lang/page/en/pages.php
@@ -20,6 +20,7 @@ return [
     'is homepage' => 'Homepage ?',
     'body' => 'Body',
     'status' => 'Status',
+    'live' => 'Page Live on Website',
     'pages were updated' => 'Pages were updated',
 
     'back to index' => 'Go back to the pages index',


### PR DESCRIPTION
I'm not sure what the best wording would be, but I have had several users complain about the current ambiguous wording.