### PR TITLE
Set default page length to 30 for tables

### DIFF
--- a/Modules/Media/Assets/js/components/MediaList.vue
+++ b/Modules/Media/Assets/js/components/MediaList.vue
@@ -126,7 +126,7 @@
                                 @size-change="handleSizeChange"
                                 @current-change="handleCurrentChange"
                                 :current-page.sync="meta.current_page"
-                                :page-sizes="[10, 20, 50, 100]"
+                                :page-sizes="[10, 20, 30, 50, 100]"
                                 :page-size="parseInt(meta.per_page)"
                                 layout="total, sizes, prev, pager, next, jumper"
                                 :total="meta.total"
@@ -165,7 +165,7 @@
                 tableIsLoading: false,
                 meta: {
                     current_page: 1,
-                    per_page: 10,
+                    per_page: 30,
                 },
                 order_meta: {
                     order_by: '',

--- a/Modules/Page/Assets/js/components/PageTableServerSide.vue
+++ b/Modules/Page/Assets/js/components/PageTableServerSide.vue
@@ -89,7 +89,7 @@
                                         @size-change="handleSizeChange"
                                         @current-change="handleCurrentChange"
                                         :current-page.sync="meta.current_page"
-                                        :page-sizes="[10, 20, 50, 100]"
+                                        :page-sizes="[10, 20, 30, 50, 100]"
                                         :page-size="parseInt(meta.per_page)"
                                         layout="total, sizes, prev, pager, next, jumper"
                                         :total="meta.total">
@@ -118,7 +118,7 @@
                 data,
                 meta: {
                     current_page: 1,
-                    per_page: 10,
+                    per_page: 30,
                 },
                 order_meta: {
                     order_by: '',

--- a/Modules/User/Assets/js/components/RoleTable.vue
+++ b/Modules/User/Assets/js/components/RoleTable.vue
@@ -73,7 +73,7 @@
                                         @size-change="handleSizeChange"
                                         @current-change="handleCurrentChange"
                                         :current-page.sync="meta.current_page"
-                                        :page-sizes="[10, 20, 50, 100]"
+                                        :page-sizes="[10, 20, 30, 50, 100]"
                                         :page-size="parseInt(meta.per_page)"
                                         layout="total, sizes, prev, pager, next, jumper"
                                         :total="meta.total">
@@ -100,7 +100,7 @@
                 data: [],
                 meta: {
                     current_page: 1,
-                    per_page: 10,
+                    per_page: 30,
                 },
                 order_meta: {
                     order_by: '',

--- a/Modules/User/Assets/js/components/UserTable.vue
+++ b/Modules/User/Assets/js/components/UserTable.vue
@@ -80,7 +80,7 @@
                                         @size-change="handleSizeChange"
                                         @current-change="handleCurrentChange"
                                         :current-page.sync="meta.current_page"
-                                        :page-sizes="[10, 20, 50, 100]"
+                                        :page-sizes="[10, 20, 30, 50, 100]"
                                         :page-size="parseInt(meta.per_page)"
                                         layout="total, sizes, prev, pager, next, jumper"
                                         :total="meta.total">
@@ -107,7 +107,7 @@
                 data: [],
                 meta: {
                     current_page: 1,
-                    per_page: 10,
+                    per_page: 30,
                 },
                 order_meta: {
                     order_by: '',


### PR DESCRIPTION
10 seems to be so small, especially in the media list