### PR TITLE
Extract vendor packages from main JS bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["es2015", "stage-3"]
+    "plugins": [
+        "syntax-dynamic-import",
+        "transform-object-rest-spread"
+    ],
+    "presets": [
+        ["env"]
+    ]
 }

--- a/Themes/Adminlte/views/layouts/master.blade.php
+++ b/Themes/Adminlte/views/layouts/master.blade.php
@@ -88,6 +88,8 @@
     };
 </script>
 
+<script src="{{ mix('js/manifest.js') }}"></script>
+<script src="{{ mix('js/vendor.js') }}"></script>
 <script src="{{ mix('js/app.js') }}"></script>
 
 <?php if (is_module_enabled('Notification')): ?>

--- a/package.json
+++ b/package.json
@@ -10,33 +10,35 @@
     "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-stage-3": "^6.24.1",
     "bootstrap-sass": "^3.3.7",
     "cross-env": "^5.2.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-vue": "^4.5.0",
-    "laravel-mix": "^2.1.11"
+    "laravel-mix": "^2.1.14"
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-3": "^6.24.1",
-    "element-ui": "^2.1.0",
+    "element-ui": "^2.4.7",
     "font-awesome": "^4.7.0",
     "form-backend-validation": "^2.3.3",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "typy": "^2.0.1",
-    "vue": "^2.5.16",
+    "vue": "^2.5.17",
     "vue-data-tables": "^3.4.0",
     "vue-events": "^3.1.0",
-    "vue-i18n": "^8.0.0",
-    "vue-router": "^3.0.0",
+    "vue-i18n": "^8.1.0",
+    "vue-router": "^3.0.1",
     "vue-shortkey": "^3.1.6",
     "vue-simplemde": "^0.4.8",
-    "vue-template-compiler": "^2.5.16"
+    "vue-template-compiler": "^2.5.17"
   }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,5 +1,9 @@
 const mix = require('laravel-mix');
 
+if (mix.inProduction()) {
+    mix.sourceMaps().disableNotifications().version();
+}
+
 /*
  |--------------------------------------------------------------------------
  | Mix Asset Management
@@ -12,4 +16,5 @@ const mix = require('laravel-mix');
  */
 
 mix.js('resources/assets/js/app.js', 'public/js')
+    .extract(['vue', 'vue-i18n', 'vue-events', 'vue-router', 'vue-shortkey', 'vue-simplemde'])
     .sass('resources/assets/sass/app.scss', 'public/css');


### PR DESCRIPTION
This gives us smaller files sizes, as well as a file that will hardly ever change for the vendor libraries.

I also bumped the minimum versions of some packages (I had to update the Babel stuff, too, when it complained about `es2015` and `stage-3`). I've been running these versions, and there appear to have been no breaking changes. At least nothing that affects us.

I also enabled Mix's versioning for production builds, so they can be cached for longer periods of time than development builds.