### PR TITLE
Fix menu item parents not being loaded into dropdown

### DIFF
--- a/Modules/Menu/Http/Controllers/Admin/MenuItemController.php
+++ b/Modules/Menu/Http/Controllers/Admin/MenuItemController.php
@@ -84,7 +84,7 @@ class MenuItemController extends AdminBaseController
      */
     private function getMenuSelect($menu)
     {
-        return $menu->menuitems()->where('is_root', '!=', true)->get()->nest()->listsFlattened('title');
+        return $menu->menuitems()->where('is_root', '!=', true)->get()->noCleaning()->nest()->listsFlattened('title');
     }
 
     /**


### PR DESCRIPTION
This also means that when you edit and save a menu item, it gets moved out of its parent to the root of the menu.

I've narrowed this down to this point: [TypiCMS/NestableCollection/src/NestableCollection.php#L66](https://github.com/TypiCMS/NestableCollection/blob/447736c3de72dc6ba994b9e339c203e35d13999e/src/NestableCollection.php#L66) (actual function here: [TypiCMS/NestableCollection/src/NestableCollection.php#L162-L181](https://github.com/TypiCMS/NestableCollection/blob/447736c3de72dc6ba994b9e339c203e35d13999e/src/NestableCollection.php#L162-L181))

I am unable to figure out why this is removing ALL menu items, even if they do have a parent...