### PR TITLE
Change due to version 1.3 of laravel-localization

### DIFF
--- a/Modules/Core/Http/Middleware/LocaleSessionRedirectMiddleware.php
+++ b/Modules/Core/Http/Middleware/LocaleSessionRedirectMiddleware.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Modules\Core\Http\Middleware;
+
+use Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect;
+
+class LocaleSessionRedirectMiddleware extends LocaleSessionRedirect
+{
+}

--- a/Modules/Core/Providers/CoreServiceProvider.php
+++ b/Modules/Core/Providers/CoreServiceProvider.php
@@ -43,6 +43,7 @@ class CoreServiceProvider extends ServiceProvider
             'auth.admin'            => 'AdminMiddleware',
             'public.checkLocale'    => 'PublicMiddleware',
             'localizationRedirect'  => 'LocalizationMiddleware',
+            'localeSessionRedirect' => 'LocaleSessionRedirectMiddleware',
             'can' => 'Authorization',
         ],
     ];

--- a/Modules/Core/Providers/RoutingServiceProvider.php
+++ b/Modules/Core/Providers/RoutingServiceProvider.php
@@ -55,7 +55,7 @@ abstract class RoutingServiceProvider extends ServiceProvider
         $router->group([
             'namespace' => $this->namespace,
             'prefix' => LaravelLocalization::setLocale(),
-            'middleware' => ['localizationRedirect', 'web'],
+            'middleware' => ['localizationRedirect','localeSessionRedirect','web'],
         ], function (Router $router) {
             $this->loadBackendRoutes($router);
             $this->loadFrontendRoutes($router);

--- a/Modules/Core/Providers/RoutingServiceProvider.php
+++ b/Modules/Core/Providers/RoutingServiceProvider.php
@@ -55,7 +55,7 @@ abstract class RoutingServiceProvider extends ServiceProvider
         $router->group([
             'namespace' => $this->namespace,
             'prefix' => LaravelLocalization::setLocale(),
-            'middleware' => ['localizationRedirect','localeSessionRedirect','web'],
+            'middleware' => ['localizationRedirect', 'localeSessionRedirect', 'web'],
         ], function (Router $router) {
             $this->loadBackendRoutes($router);
             $this->loadFrontendRoutes($router);

--- a/Modules/Core/Providers/RoutingServiceProvider.php
+++ b/Modules/Core/Providers/RoutingServiceProvider.php
@@ -55,7 +55,7 @@ abstract class RoutingServiceProvider extends ServiceProvider
         $router->group([
             'namespace' => $this->namespace,
             'prefix' => LaravelLocalization::setLocale(),
-            'middleware' => ['localizationRedirect', 'localeSessionRedirect', 'web'],
+            'middleware' => ['localeSessionRedirect', 'localizationRedirect', 'web'],
         ], function (Router $router) {
             $this->loadBackendRoutes($router);
             $this->loadFrontendRoutes($router);


### PR DESCRIPTION
Hi,

This version is using version 1.3.* of mcamara/laravel-localization

https://github.com/AsgardCms/Platform/blob/master/Modules/Core/composer.json#L29

Since a few time, the logic to add the locale prefix is not anymore on the localizationRedirect 

https://github.com/mcamara/laravel-localization/blob/master/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php

But on LocaleSessionRedirect instead

https://github.com/mcamara/laravel-localization/blob/master/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php



