### PR TITLE
Update InstallCommand.php

### DIFF
--- a/Modules/Core/Console/InstallCommand.php
+++ b/Modules/Core/Console/InstallCommand.php
@@ -72,7 +72,7 @@ class InstallCommand extends Command
         ])->install($this);
 
         if ($success) {
-            $this->info('Platform ready! You can now login with your username and password at /backend');
+            $this->info('Platform ready! You can now login with your username and password at /en/backend');
         }
     }
 


### PR DESCRIPTION
New install (and new to asgard), installer referred to going to /backend which failed. Then I found in the bugs history someone else found this and the solution was to go to /en/backend. If I go to the main front page it showed the correct link. Figured it should also be in the console installer to prevent confusion.