### PR TITLE
Fix mismatched implementation from PR #702

### DIFF
--- a/Modules/Translation/Repositories/LocaleRepository.php
+++ b/Modules/Translation/Repositories/LocaleRepository.php
@@ -35,5 +35,5 @@ interface LocaleRepository
      * @param array $locales
      * @return Collection
      */
-    public function translatableLocales(array $locales = null): Collection;
+    public function translatableLocales(): Collection;
 }


### PR DESCRIPTION
Currently, there is an exception:

```
Declaration of Modules\Translation\Repositories\Eloquent\EloquentLocaleRepository::translatableLocales(): Illuminate\Support\Collection must be compatible with Modules\Translation\Repositories\LocaleRepository::translatableLocales(array $locales = NULL): Illuminate\Support\Collection
```

Contract: https://github.com/AsgardCms/Platform/blob/265d5cf16d3e005c07a7672aea3d6a724fd37fcc/Modules/Translation/Repositories/LocaleRepository.php#L38
Implementation: https://github.com/AsgardCms/Platform/blob/265d5cf16d3e005c07a7672aea3d6a724fd37fcc/Modules/Translation/Repositories/Eloquent/EloquentLocaleRepository.php#L89