### PR TITLE
Update `league/commonmark` to `^0.19`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "barryvdh/laravel-debugbar": "~3.0",
         "orchestra/testbench": "^3.5",
         "league/flysystem-aws-s3-v3": "^1.0",
-        "league/commonmark": "^0.15.4",
+        "league/commonmark": "^0.19",
         "predis/predis": "^1.1",
         "roave/security-advisories": "dev-master"
     },


### PR DESCRIPTION
Roave/SecurityAdvisories conflict with `"league/commonmark": "<0.18.3"` so we need to update it for install with composer