### PR TITLE
fix folder deletion bug (#715)

### DIFF
--- a/Modules/Media/Repositories/Eloquent/EloquentFolderRepository.php
+++ b/Modules/Media/Repositories/Eloquent/EloquentFolderRepository.php
@@ -82,7 +82,7 @@ class EloquentFolderRepository extends EloquentBaseRepository implements FolderR
     {
         $path = $folder->path->getRelativeUrl();
 
-        return $this->model->where('path', 'like', "{$path}%")->get();
+        return $this->model->where('path', 'like', "{$path}/%")->get();
     }
 
     public function allNested(): NestedFoldersCollection


### PR DESCRIPTION
prevent deletion of folders that are NOT actually subfolders and only
start with the same sequence of characters. Originally, if I have two
or more folders on the same level:
`slider`
`slider-homepage`
and I delete only the `slider` one, `slider-homepage` would get deleted
as well.

This change makes sure the deleted folders are actually subfolders of
the deleted one.