### PR TITLE
Fix errors on permissions forms (Users and Roles)

### DIFF
--- a/Modules/User/Assets/js/components/AsgardPermissions.vue
+++ b/Modules/User/Assets/js/components/AsgardPermissions.vue
@@ -46,7 +46,7 @@
                                 </div>
                             </div>
                             <div class="col-md-9">
-                                <el-radio-group v-model="permissions[`${subPermissionTitle}.${permissionAction}`]">
+                                <el-radio-group v-model="permissions[`${subPermissionTitle}`][`${permissionAction}`]">
                                     <el-radio-button :label="1" @click="triggerEvent">{{ trans('roles.allow') }}</el-radio-button>
                                     <el-radio-button v-if="!isRole" :label="0" @click="triggerEvent">{{ trans('roles.inherit') }}</el-radio-button>
                                     <el-radio-button :label="-1" @click="triggerEvent">{{ trans('roles.deny') }}</el-radio-button>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -8662,22 +8662,20 @@ var render = function() {
                                 {
                                   model: {
                                     value:
-                                      _vm.permissions[
-                                        subPermissionTitle +
-                                          "." +
-                                          permissionAction
+                                      _vm.permissions["" + subPermissionTitle][
+                                        "" + permissionAction
                                       ],
                                     callback: function($$v) {
                                       _vm.$set(
-                                        _vm.permissions,
-                                        subPermissionTitle +
-                                          "." +
-                                          permissionAction,
+                                        _vm.permissions[
+                                          "" + subPermissionTitle
+                                        ],
+                                        "" + permissionAction,
                                         $$v
                                       )
                                     },
                                     expression:
-                                      "permissions[`${subPermissionTitle}.${permissionAction}`]"
+                                      "permissions[`${subPermissionTitle}`][`${permissionAction}`]"
                                   }
                                 },
                                 [


### PR DESCRIPTION
The dot notation doesn't work mixed with the brackets.

Not sure how I missed this before...