### PR TITLE
Fix `compact` errors in PHP 7.3

### DIFF
--- a/Modules/Media/Blade/MediaMultipleDirective.php
+++ b/Modules/Media/Blade/MediaMultipleDirective.php
@@ -34,6 +34,8 @@ class MediaMultipleDirective
 
         $name = $this->name ?: ucwords(str_replace('_', ' ', $this->zone));
 
+        $media = null;
+
         if ($this->entity !== null) {
             $media = $this->entity->filesByZone($this->zone)->get();
         }

--- a/Modules/Media/Blade/MediaSingleDirective.php
+++ b/Modules/Media/Blade/MediaSingleDirective.php
@@ -34,6 +34,8 @@ class MediaSingleDirective
 
         $name = $this->name ?: ucwords(str_replace('_', ' ', $this->zone));
 
+        $media = null;
+
         if ($this->entity !== null) {
             $media = $this->entity->filesByZone($this->zone)->first();
         }


### PR DESCRIPTION
In PHP 7.3 `compact` no longer silently discards unset variables: https://www.php.net/manual/en/function.compact.php#refsect1-function.compact-changelog