### PR TITLE
Update php version in app docker image to 7.1

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -16,19 +16,19 @@ RUN add-apt-repository ppa:nginx/stable \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         nginx \
-        php7.0-fpm \
-        php7.0-cli \
-        php7.0-xdebug \
-        php7.0-pdo \
-        php7.0-pdo-mysql \
-        php7.0-sqlite3 \
-        php7.0-xml \
-        php7.0-mbstring \
-        php7.0-tokenizer \
-        php7.0-zip \
-        php7.0-mcrypt \
-        php7.0-gd \
-        php7.0-curl \
+        php7.1-fpm \
+        php7.1-cli \
+        php7.1-xdebug \
+        php7.1-pdo \
+        php7.1-pdo-mysql \
+        php7.1-sqlite3 \
+        php7.1-xml \
+        php7.1-mbstring \
+        php7.1-tokenizer \
+        php7.1-zip \
+        php7.1-mcrypt \
+        php7.1-gd \
+        php7.1-curl \
         curl \
     && mkdir /run/php \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
@@ -36,7 +36,7 @@ RUN add-apt-repository ppa:nginx/stable \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
     && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
-    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > /etc/php/7.0/mods-available/blackfire.ini \
+    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > /etc/php/7.1/mods-available/blackfire.ini \
     && phpenmod blackfire \
     && apt-get remove -y --purge software-properties-common curl \
     && apt-get clean \
@@ -44,15 +44,15 @@ RUN add-apt-repository ppa:nginx/stable \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY default /etc/nginx/sites-enabled/default
-COPY php.ini /etc/php/7.0/fpm/php.ini
-COPY php-fpm.conf /etc/php/7.0/fpm/php-fpm.conf
+COPY php.ini /etc/php/7.1/fpm/php.ini
+COPY php-fpm.conf /etc/php/7.1/fpm/php-fpm.conf
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-COPY laravel.ini /etc/php/7.0/fpm/conf.d/laravel.ini
-#COPY disabled-xdebug.ini /etc/php/7.0/mods-available/xdebug.ini
-COPY enabled-xdebug.ini /etc/php/7.0/mods-available/xdebug.ini
+COPY laravel.ini /etc/php/7.1/fpm/conf.d/laravel.ini
+#COPY disabled-xdebug.ini /etc/php/7.1/mods-available/xdebug.ini
+COPY enabled-xdebug.ini /etc/php/7.1/mods-available/xdebug.ini
 
-RUN /etc/init.d/php7.0-fpm restart
+RUN /etc/init.d/php7.1-fpm restart
 
 RUN mkdir /tmp/certgen
 WORKDIR /tmp/certgen


### PR DESCRIPTION
# Description

The package `league/commonmark` needs `php ^7.1` from version `0.19.0` which is updated in the `composer.json` since d717670bcd7c10554555befb944eb734bd971ae9. However the `Dockerfile` has not been updated and cannot perform a `composer install` because the PHP version is only `7.0` which is too low for `league/commonmark`.

# Notes to the documentation

I would happily update the documentation pages as well if you want me to :)

## Requirements

The PHP 7.0 or higher part is no longer a valid requirement in the [Minimum System Requirements section](https://asgardcms.com/docs/v3/getting-started/installation#minimum-system-requirements).

## Docker install

I've noticed that the documentation only mentions to run `dcp up` and `dcp artisan asgard:install` in the [Install section](https://asgardcms.com/docs/v3/getting-started/docker#install-asgardcms) although a `dcp composer install` need to be run before `asgard:install`.
Without installing composer packages, we cannot run any `artisan` command since `vendor/autoload.php` does not present.