### PR TITLE
Allow set cache time on remember function

### DIFF
--- a/Modules/Core/Repositories/Cache/BaseCacheDecorator.php
+++ b/Modules/Core/Repositories/Cache/BaseCacheDecorator.php
@@ -26,15 +26,9 @@ abstract class BaseCacheDecorator implements BaseRepository
      */
     protected $locale;
 
-    /**
-     * @var int caching time
-     */
-    protected $cacheTime;
-
     public function __construct()
     {
-        $this->cache = app(Repository::class);
-        $this->cacheTime = app(ConfigRepository::class)->get('cache.time', 60);
+        $this->cache = app(Repository::class);        
         $this->locale = app()->getLocale();
     }
 
@@ -188,10 +182,8 @@ abstract class BaseCacheDecorator implements BaseRepository
             $store = $store->tags([$this->entityName, 'global']);
         }
 
-        $cacheTime = $this->cacheTime;
-        if (null !== $time) {
-            $cacheTime = $time;
-        }
+        // If no $time is passed, just use the default from config
+        $cacheTime = $time ?? app(ConfigRepository::class)->get('cache.time', 60);
 
         return $store->remember($cacheKey, $cacheTime, $callback);
     }

--- a/Modules/Core/Repositories/Cache/BaseCacheDecorator.php
+++ b/Modules/Core/Repositories/Cache/BaseCacheDecorator.php
@@ -177,7 +177,7 @@ abstract class BaseCacheDecorator implements BaseRepository
      * @param null|string $key
      * @return mixed
      */
-    protected function remember(\Closure $callback, $key = null)
+    protected function remember(\Closure $callback, $key = null, $time = null)
     {
         $cacheKey = $this->makeCacheKey($key);
 
@@ -187,7 +187,12 @@ abstract class BaseCacheDecorator implements BaseRepository
             $store = $store->tags([$this->entityName, 'global']);
         }
 
-        return $store->remember($cacheKey, $this->cacheTime, $callback);
+        $cacheTime = $this->cacheTime;
+        if (null !== $time) {
+            $cacheTime = $time;
+        }
+
+        return $store->remember($cacheKey, $cacheTime, $callback);
     }
 
     /**

--- a/Modules/Core/Repositories/Cache/BaseCacheDecorator.php
+++ b/Modules/Core/Repositories/Cache/BaseCacheDecorator.php
@@ -175,6 +175,7 @@ abstract class BaseCacheDecorator implements BaseRepository
     /**
      * @param \Closure $callback
      * @param null|string $key
+     * @param null|int    $time
      * @return mixed
      */
     protected function remember(\Closure $callback, $key = null, $time = null)


### PR DESCRIPTION
Since the remember method could be used for a lot of different reason and to store different information for a different amount of time the best think is allow user to define the amount of time.

Right not the whole cache decorator use the same amount of time for each store.

I think that in this way we can manage cache with much more flexibility.