### PR TITLE
Fix folder size test

### DIFF
--- a/Modules/Media/Tests/MaxFolderSizeRuleTest.php
+++ b/Modules/Media/Tests/MaxFolderSizeRuleTest.php
@@ -27,7 +27,7 @@ final class MaxFolderSizeRuleTest extends MediaTestCase
     /** @test */
     public function it_validates_max_folder_size_is_valid()
     {
-        $this->app['config']->set('asgard.media.config.max-total-size', 1000); // Mocked folder size: 510
+        $this->app['config']->set('asgard.media.config.max-total-size', 10000); // Mocked folder size: 480; Mocked image: ~8192
 
         $validator = $this->buildValidator(UploadedFile::fake()->image('avatar.jpg'));
         $this->assertTrue($validator->passes());
@@ -36,7 +36,7 @@ final class MaxFolderSizeRuleTest extends MediaTestCase
     /** @test */
     public function it_validates_max_folder_size_is_invalid()
     {
-        $this->app['config']->set('asgard.media.config.max-total-size', 100); // Mocked folder size: 510
+        $this->app['config']->set('asgard.media.config.max-total-size', 100);
 
         $validator = $this->buildValidator(UploadedFile::fake()->image('avatar.jpg'));
         $this->assertFalse($validator->passes());


### PR DESCRIPTION
It looks like at some point the image's size was increased somehow. That's my only guess since the mocked folder size went down in my testing (I dumped all the things from the validator 😆).

I also noted the size of the mocked image, so we can watch it over time.