### PR TITLE
Prevent environment variable leakage when debug is on

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -49,6 +49,37 @@ return [
 
     'debug' => env('APP_DEBUG', false),
 
+    'debug_blacklist' => [
+        '_ENV' => [
+            'APP_KEY',
+            'DB_USERNAME',
+            'DB_PASSWORD',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'PUSHER_APP_KEY',
+            'PUSHER_APP_SECRET',
+        ],
+
+        '_SERVER' => [
+            'APP_KEY',
+            'DB_USERNAME',
+            'DB_PASSWORD',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'PUSHER_APP_KEY',
+            'PUSHER_APP_SECRET',
+        ],
+
+        '_POST' => [
+            'password',
+            'password_confirmation',
+        ],
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Application URL


### PR DESCRIPTION
I apparently forgot about this and didn't submit the PR... Ugh.

In February, someone was able to grab my Postmark credentials from a Google search and sent about 10,000 spam messages. They were able to do this because I had debug mode on and an error on a page that Google apparently crawled and cached.

This PR prevents certain environment variables (as well as POST data) from being displayed on Whoops.

I have been running this in production since February with no more incidents of credential leakage.