### PR TITLE
Prevent Last API Key Deletion

### DIFF
--- a/Modules/Translation/Resources/lang/user/en/users.php
+++ b/Modules/Translation/Resources/lang/user/en/users.php
@@ -58,6 +58,7 @@ return [
     'generate one' => 'Generate one.',
     'token generated' => 'API token was successfully generated',
     'token deleted' => 'API token was successfully deleted',
+    'last token can not be deleted' => 'Last token can not be deleted',
     'list user' => 'List users',
     'create user' => 'Create users',
     'edit user' => 'Edit users',

--- a/Modules/User/Http/Controllers/Admin/Account/ApiKeysController.php
+++ b/Modules/User/Http/Controllers/Admin/Account/ApiKeysController.php
@@ -41,6 +41,11 @@ class ApiKeysController extends AdminBaseController
 
     public function destroy(UserToken $userToken)
     {
+        if ($this->userToken->allForUser($this->auth->id())->count() === 1) {
+            return redirect()->route('admin.account.api.index')
+                ->withFail(trans('user::users.last token can not be deleted'));
+        }
+
         $this->userToken->destroy($userToken);
 
         return redirect()->route('admin.account.api.index')

--- a/Modules/User/Http/Controllers/Api/ApiKeysController.php
+++ b/Modules/User/Http/Controllers/Api/ApiKeysController.php
@@ -47,6 +47,14 @@ class ApiKeysController extends Controller
 
     public function destroy(UserToken $userToken)
     {
+        if ($this->userToken->allForUser($this->auth->id())->count() === 1) {
+            return response()->json([
+                'errors' => true,
+                'message' => trans('user::users.last token can not be deleted'),
+                'data' => ApiKeysTransformer::collection($this->userToken->allForUser($this->auth->id())),
+            ]);
+        }
+
         $this->userToken->destroy($userToken);
         $tokens = $this->userToken->allForUser($this->auth->id());
 

--- a/Modules/User/changelog.yml
+++ b/Modules/User/changelog.yml
@@ -3,6 +3,8 @@ versions:
     "@unreleased":
         added:
             - Laravel 5.6 compatibility
+        changed:
+            - Prevents the deletion of the last API token
     "3.6.0":
          changed:
          - Adding a test the user token is correctly generated


### PR DESCRIPTION
This PR prevents users from deleting their last API key as doing so causes most of the backend to stop working correctly.