### PR TITLE
Fixes Changelog Views

### DIFF
--- a/Modules/Workshop/Resources/views/admin/modules/partials/changelog.blade.php
+++ b/Modules/Workshop/Resources/views/admin/modules/partials/changelog.blade.php
@@ -1,7 +1,7 @@
 <?php foreach ($changelog['versions'] as $version => $info): ?>
 <dl class="dl-horizontal">
     <dt>
-        <?php if (str_contains($version, ['unreleased', 'dev'])): ?>
+        <?php if (Illuminate\Support\Str::contains($version, ['unreleased', 'dev'])): ?>
             {{ $version }}
         <?php else: ?>
             <a href="{{ $changelog['url'].'/releases/tag/'.$version }}" target="_blank">


### PR DESCRIPTION
This PR fixes the module/theme changelog views. It was calling `str_contains` which is now defined in `Symfony\Polyfill\Php80` and does not accept an array as the second argument like the Laravel helper function did.