### PR TITLE
Prevent Cross User Token Deletion

### DIFF
--- a/Modules/User/Http/Controllers/Api/ApiKeysController.php
+++ b/Modules/User/Http/Controllers/Api/ApiKeysController.php
@@ -5,6 +5,7 @@ namespace Modules\User\Http\Controllers\Api;
 use Illuminate\Routing\Controller;
 use Modules\User\Contracts\Authentication;
 use Modules\User\Entities\UserToken;
+use Modules\User\Http\Requests\DeleteUserTokenRequest;
 use Modules\User\Repositories\UserTokenRepository;
 use Modules\User\Transformers\ApiKeysTransformer;
 
@@ -45,7 +46,7 @@ class ApiKeysController extends Controller
         ]);
     }
 
-    public function destroy(UserToken $userToken)
+    public function destroy(DeleteUserTokenRequest $request, UserToken $userToken)
     {
         $this->userToken->destroy($userToken);
         $tokens = $this->userToken->allForUser($this->auth->id());

--- a/Modules/User/Http/Requests/DeleteUserTokenRequest.php
+++ b/Modules/User/Http/Requests/DeleteUserTokenRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\User\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteUserTokenRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [];
+    }
+
+    public function authorize()
+    {
+        return ($this->userTokenId->user->id === $this->user()->id);
+    }
+
+    public function messages()
+    {
+        return [];
+    }
+}

--- a/Modules/User/changelog.yml
+++ b/Modules/User/changelog.yml
@@ -3,6 +3,8 @@ versions:
     "@unreleased":
         added:
             - Laravel 5.6 compatibility
+        changed:
+            - Prevent users from deleting other users API tokens
     "3.6.0":
          changed:
          - Adding a test the user token is correctly generated


### PR DESCRIPTION
This PR adds validation to prevent users from deleting API tokens that don't belong to them