### PR TITLE
Add missing method to Locales cache decorator

### DIFF
--- a/Modules/Translation/Repositories/Cache/CacheLocaleDecorator.php
+++ b/Modules/Translation/Repositories/Cache/CacheLocaleDecorator.php
@@ -28,6 +28,17 @@ class CacheLocaleDecorator extends BaseCacheDecorator implements LocaleRepositor
     }
 
     /** {@inheritdoc} */
+    public function listLocalesForSelect(LocaleCodeRequest $request): Collection
+    {
+        return $this->remember(
+            function () use ($request) {
+                return $this->repository->listLocalesForSelect($request);
+            },
+            'locales_for_select'
+        );
+    }
+
+    /** {@inheritdoc} */
     public function availableLocales() : Collection
     {
         return $this->remember(


### PR DESCRIPTION
Tried to update a site today to get the recent changes and had this error:

```
PHP Fatal error:  Class Modules\Translation\Repositories\Cache\CacheLocaleDecorator contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Modules\Translation\Repositories\LocaleRepository::listLocalesForSelect)
```

This PR adds the missing method to the cache decorator.