### PR TITLE
Fixes alignment of Module/Theme version

### DIFF
--- a/Modules/Workshop/Resources/views/admin/modules/show.blade.php
+++ b/Modules/Workshop/Resources/views/admin/modules/show.blade.php
@@ -68,7 +68,7 @@
                     <div class="row">
                         <div class="col-sm-12 module-details">
                             <div class="module-title-wrap">
-                                <div class="module-type pull-left">
+                                <div class="module-type">
                                     <i class="fa fa-cube"></i>
                                     <span>{{ module_version($module) }}</span>
                                 </div>

--- a/Modules/Workshop/Resources/views/admin/modules/show.blade.php
+++ b/Modules/Workshop/Resources/views/admin/modules/show.blade.php
@@ -19,14 +19,22 @@
 
 @push('css-stack')
     <style>
+        .module-title-wrap {
+            display: flex;
+            align-items: center;
+        }
         .module-type {
             text-align: center;
+            margin-right: 10px;
         }
         .module-type span {
             display: block;
         }
         .module-type i {
             font-size: 124px;
+        }
+        .module-title {
+            margin: 0;
         }
         form {
             display: inline;
@@ -59,11 +67,13 @@
                 <div class="box-body">
                     <div class="row">
                         <div class="col-sm-12 module-details">
-                            <div class="module-type pull-left">
-                                <i class="fa fa-cube"></i>
-                                <span>{{ module_version($module) }}</span>
+                            <div class="module-title-wrap">
+                                <div class="module-type pull-left">
+                                    <i class="fa fa-cube"></i>
+                                    <span>{{ module_version($module) }}</span>
+                                </div>
+                                <h2 class="module-title">{{ ucfirst($module->getName()) }}</h2>
                             </div>
-                            <h2>{{ ucfirst($module->getName()) }}</h2>
                             <p>{{ $module->getDescription() }}</p>
                         </div>
                     </div>

--- a/Modules/Workshop/Resources/views/admin/themes/show.blade.php
+++ b/Modules/Workshop/Resources/views/admin/themes/show.blade.php
@@ -60,7 +60,7 @@
                     <div class="row">
                         <div class="col-sm-6 module-details">
                             <div class="module-title-wrap">
-                                <div class="module-type pull-left">
+                                <div class="module-type">
                                     <i class="fa fa-picture-o"></i>
                                     <span>
                                         {{  theme_version($theme) }}

--- a/Modules/Workshop/Resources/views/admin/themes/show.blade.php
+++ b/Modules/Workshop/Resources/views/admin/themes/show.blade.php
@@ -19,8 +19,13 @@
 
 @push('css-stack')
     <style>
+        .module-title-wrap {
+            display: flex;
+            align-items: center;
+        }
         .module-type {
             text-align: center;
+            margin-right: 10px;
         }
         .module-type span {
             display: block;
@@ -29,8 +34,8 @@
             font-size: 124px;
             margin-right: 20px;
         }
-        .module-type span {
-            margin-left: -20px;
+        .module-title {
+            margin: 0;
         }
         form {
             display: inline;
@@ -54,13 +59,15 @@
                 <div class="box-body">
                     <div class="row">
                         <div class="col-sm-6 module-details">
-                            <div class="module-type pull-left">
-                                <i class="fa fa-picture-o"></i>
-                                <span>
-                                    {{  theme_version($theme) }}
-                                </span>
+                            <div class="module-title-wrap">
+                                <div class="module-type pull-left">
+                                    <i class="fa fa-picture-o"></i>
+                                    <span>
+                                        {{  theme_version($theme) }}
+                                    </span>
+                                </div>
+                                <h2 class="module-title">{{ ucfirst($theme->getName()) }}</h2>
                             </div>
-                            <h2>{{ ucfirst($theme->getName()) }}</h2>
                             <p>{{ $theme->getDescription() }}</p>
                         </div>
                         <div class="col-sm-6">


### PR DESCRIPTION
Fixes the styles of Module/Theme version in Workshop module

Previous style (Currently looks crooked in Themes):

![Screenshot from 2020-10-30 14-09-22](https://user-images.githubusercontent.com/1587455/97716361-6de71780-1abb-11eb-9868-fd1526631059.png)

New style (Nicer in general for both Themes/Modules):

![Screenshot from 2020-10-30 14-19-17](https://user-images.githubusercontent.com/1587455/97716372-73446200-1abb-11eb-8f25-621195a2ff7c.png)
