### PR TITLE
Theme/AdminLTE - meta base tag must specify the base for all relative

### DIFF
--- a/Themes/Adminlte/views/layouts/master.blade.php
+++ b/Themes/Adminlte/views/layouts/master.blade.php
@@ -11,7 +11,7 @@
         <meta name="user-api-token" content="{{ $currentUser->getFirstApiKey() }}">
         <meta name="current-locale" content="{{ locale() }}">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
-        <base href="{{ url('/') }}">
+        <base href="{{ url()->current() }}">
         <link rel="canonical" href="{{ request()->url() }}">
 
         @foreach($cssFiles as $css)


### PR DESCRIPTION
`<base href="{{ url()->current() }}">` cause this meta specify the base for all links also anchor https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
And if it only `url()`, we have wrong urls in languages tab and other anchors, with a buggy behavior