### PR TITLE
Fixed delete of file that was treated like folder

### DIFF
--- a/Modules/Media/Transformers/MediaTransformer.php
+++ b/Modules/Media/Transformers/MediaTransformer.php
@@ -81,7 +81,7 @@ class MediaTransformer extends JsonResource
 
     private function getDeleteUrl()
     {
-        if ($this->resource->isImage()) {
+        if (!$this->resource->isFolder()) {
             return route('api.media.media.destroy', $this->resource->id);
         }
 


### PR DESCRIPTION
isImage() get a delete url for file's and image, and only isFolder() have different url so change condition for return a delete_url for file's and image's and only instead isFolder() the delete url for folder