### PR TITLE
Laravel changed `debug_blacklist` to `debug_hide`

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -49,7 +49,7 @@ return [
 
     'debug' => env('APP_DEBUG', false),
 
-    'debug_blacklist' => [
+    'debug_hide' => [
         '_ENV' => [
             'APP_KEY',
             'DB_USERNAME',


### PR DESCRIPTION
Looks like they did it in v7 (it was still `debug_blacklist` in v6): https://laravel.com/docs/7.x/configuration#hiding-environment-variables-from-debug