### PR TITLE
Selects alt text from media library when adding image via CKEditor

### DIFF
--- a/Modules/Media/Resources/views/admin/grid/ckeditor.blade.php
+++ b/Modules/Media/Resources/views/admin/grid/ckeditor.blade.php
@@ -10,9 +10,20 @@
                 return ( match && match.length > 1 ) ? match[1] : null;
             }
 
+            var imageButton = $(this);
             var funcNum = getUrlParam('CKEditorFuncNum');
 
-            window.opener.CKEDITOR.tools.callFunction(funcNum, $(this).data('file-path'));
+            window.opener.CKEDITOR.tools.callFunction(funcNum, imageButton.data('file-path'), function () {
+                var dialog = this.getDialog();
+                if (dialog.getName() !== 'image') {
+                    return;
+                }
+                var altField = dialog.getContentElement('info', 'txtAlt');
+                var altValue = imageButton.data('alt');
+                if (altField && altValue) {
+                    altField.setValue(altValue);
+                }
+            });
             window.close();
         });
     });

--- a/Modules/Media/Resources/views/admin/grid/partials/content.blade.php
+++ b/Modules/Media/Resources/views/admin/grid/partials/content.blade.php
@@ -76,14 +76,23 @@
                                     <ul class="dropdown-menu" role="menu">
                                         <?php foreach ($thumbnails as $thumbnail): ?>
                                         <li data-file-path="{{ Imagy::getThumbnail($file->path, $thumbnail->name()) }}"
-                                            data-id="{{ $file->id }}" data-media-type="{{ $file->media_type }}"
-                                            data-mimetype="{{ $file->mimetype }}" class="jsInsertImage">
+                                            data-id="{{ $file->id }}"
+                                            data-media-type="{{ $file->media_type }}"
+                                            data-mimetype="{{ $file->mimetype }}"
+                                            data-alt="{{ $file->alt_attribute }}"
+                                            class="jsInsertImage"
+                                        >
                                             <a href="">{{ $thumbnail->name() }} ({{ $thumbnail->size() }})</a>
                                         </li>
                                         <?php endforeach; ?>
                                         <li class="divider"></li>
-                                        <li data-file-path="{{ $file->path }}" data-id="{{ $file->id }}"
-                                            data-media-type="{{ $file->media_type }}" data-mimetype="{{ $file->mimetype }}" class="jsInsertImage">
+                                        <li data-file-path="{{ $file->path }}"
+                                            data-id="{{ $file->id }}"
+                                            data-media-type="{{ $file->media_type }}"
+                                            data-mimetype="{{ $file->mimetype }}"
+                                            data-alt="{{ $file->alt_attribute }}"
+                                            class="jsInsertImage"
+                                        >
                                             <a href="">Original</a>
                                         </li>
                                     </ul>


### PR DESCRIPTION
When you insert an image into CKEditor from the media library, it will automatically populate the alt attribute, based on what's set as the alt attribute in the media library