### PR TITLE
Fixes alignment of admin sidebar icons and text

### DIFF
--- a/Themes/Adminlte/assets/css/asgard.css
+++ b/Themes/Adminlte/assets/css/asgard.css
@@ -72,6 +72,9 @@ footer.main-footer p.text-muted {
   padding: 10px 25px 10px 15px;
   font-size: 12px;
 }
+.sidebar-menu .menu-icon {
+  margin-right: 5px;
+}
 .sidebar-menu .append {
   margin-top: -44px;
 }

--- a/Themes/Adminlte/resources/assets/less/asgard.less
+++ b/Themes/Adminlte/resources/assets/less/asgard.less
@@ -6,6 +6,10 @@
 
 @import "skins/blue.less";
 
+.sidebar-menu .menu-icon {
+  margin-right: 5px;
+}
+
 // For the appended elements
 .sidebar-menu .append {
   margin-top: -44px;

--- a/public/themes/adminlte/css/asgard.css
+++ b/public/themes/adminlte/css/asgard.css
@@ -72,6 +72,9 @@ footer.main-footer p.text-muted {
   padding: 10px 25px 10px 15px;
   font-size: 12px;
 }
+.sidebar-menu .menu-icon {
+  margin-right: 5px;
+}
 .sidebar-menu .append {
   margin-top: -44px;
 }

--- a/resources/views/vendor/sidebar/item.blade.php
+++ b/resources/views/vendor/sidebar/item.blade.php
@@ -1,6 +1,6 @@
 <li class="@if($item->getItemClass()){{ $item->getItemClass() }}@endif @if($active)active @endif @if($item->hasItems())treeview @endif clearfix">
     <a href="{{ $item->getUrl() }}" class="@if(count($appends) > 0) hasAppend @endif" @if($item->getNewTab())target="_blank"@endif>
-        <i class="{{ $item->getIcon() }}"></i>
+        <i class="{{ $item->getIcon() }} fa-fw menu-icon"></i>
         <span>{{ $item->getName() }}</span>
 
         @foreach($badges as $badge)


### PR DESCRIPTION
Fixes size and spacing of admin sidebar icons so it looks nice, and more like the original AdminLTE theme

Before:
![Screenshot from 2021-10-29 23-33-53](https://user-images.githubusercontent.com/1587455/139508432-1dd18ef6-5cba-4825-8883-8759856595dc.png)

After:
![Screenshot from 2021-10-29 23-32-41](https://user-images.githubusercontent.com/1587455/139508422-a93f457b-7fbf-41f7-9a8d-990c7ce5f5c4.png)

