### PR TITLE
Removes unnecessary horizontal scrollbar on image picker

### DIFF
--- a/Themes/Adminlte/assets/css/asgard.css
+++ b/Themes/Adminlte/assets/css/asgard.css
@@ -32,13 +32,15 @@ ul.notifications-list li {
 .jsThumbnailImageWrapper figure {
   position: relative;
   display: inline-block;
-  margin-right: 20px;
   margin-bottom: 20px;
   background-color: #fff;
   border: 1px solid #eee;
   padding: 3px;
   border-radius: 3px;
   vertical-align: bottom;
+}
+.jsThumbnailImageWrapper figure img {
+  max-width: 100%;
 }
 .jsThumbnailImageWrapper i.removeIcon {
   position: absolute;

--- a/Themes/Adminlte/resources/assets/less/Asgard/mediaModule.less
+++ b/Themes/Adminlte/resources/assets/less/Asgard/mediaModule.less
@@ -8,13 +8,15 @@
 .jsThumbnailImageWrapper figure {
 	position: relative;
 	display: inline-block;
-	margin-right: 20px;
 	margin-bottom: 20px;
 	background-color: #fff;
 	border: 1px solid #eee;
 	padding: 3px;
 	border-radius: 3px;
 	vertical-align: bottom;
+}
+.jsThumbnailImageWrapper figure img {
+	max-width: 100%;
 }
 .jsThumbnailImageWrapper i.removeIcon {
 	position: absolute;

--- a/public/themes/adminlte/css/asgard.css
+++ b/public/themes/adminlte/css/asgard.css
@@ -32,13 +32,15 @@ ul.notifications-list li {
 .jsThumbnailImageWrapper figure {
   position: relative;
   display: inline-block;
-  margin-right: 20px;
   margin-bottom: 20px;
   background-color: #fff;
   border: 1px solid #eee;
   padding: 3px;
   border-radius: 3px;
   vertical-align: bottom;
+}
+.jsThumbnailImageWrapper figure img {
+  max-width: 100%;
 }
 .jsThumbnailImageWrapper i.removeIcon {
   position: absolute;


### PR DESCRIPTION
When the browser window isn't large enough, the image preview in the image picker can cause horizontal scrollbars to appear. There is now a max-width to prevent the image size overflowing

This scrollbar is now removed:
![Screenshot from 2021-10-29 23-48-20](https://user-images.githubusercontent.com/1587455/139509296-c1e849b2-419e-4324-b2d1-2ec308b4fef0.png)

